### PR TITLE
Add shutdown() call to finalizer

### DIFF
--- a/kinesis-client/src/main/scala/kinesis4cats/client/logging/instances/show.scala
+++ b/kinesis-client/src/main/scala/kinesis4cats/client/logging/instances/show.scala
@@ -201,7 +201,7 @@ object show {
     ShowBuilder("CreateStreamRequest")
       .add("streamName", x.streamName())
       .add("shardCount", x.shardCount())
-      .add("streamARN", x.streamModeDetails())
+      .add("streamModeDetails", x.streamModeDetails())
       .build
 
   implicit val createStreamResponseShow: Show[CreateStreamResponse] = x =>


### PR DESCRIPTION
## Changes Introduced

Sometimes the graceful shutdown runs into some race conditions which means that the scheduler does not fully shut down (even if all of the processes are complete). This adds the `shutdown` call to cleanup the scheduler afterwards.

See https://github.com/awslabs/amazon-kinesis-client/issues/616 for more information.

## Applicable linked issues

N/A

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [x] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review