### PR TITLE
Add putWithRetry

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,8 @@ lazy val shared = projectMatrix
     description := "Common shared utilities",
     libraryDependencies ++= Seq(
       Aws.Aggregation.aggregator % Test,
-      Aws.Aggregation.deaggregator % Test
+      Aws.Aggregation.deaggregator % Test,
+      Log4Cats.slf4j % Test
     )
   )
   .jvmPlatform(allScalaVersions)

--- a/docs/client/getting-started.md
+++ b/docs/client/getting-started.md
@@ -57,6 +57,8 @@ This module provides an implementation of that interface, backed by the @:source
 
 
 ```scala mdoc:compile-only
+import scala.concurrent.duration._
+
 import cats.data.NonEmptyList
 import cats.effect._
 import cats.syntax.all._
@@ -81,6 +83,16 @@ object MyApp extends IOApp {
                         Record("my-data-2".getBytes(), "some-partition-key-2"),
                         Record("my-data-3".getBytes(), "some-partition-key-3"),
                     )
+                )
+                // Retries failed records with a configured limit and duration.
+                _ <- producer.putWithRetry(
+                    NonEmptyList.of(
+                        Record("my-data".getBytes(), "some-partition-key"),
+                        Record("my-data-2".getBytes(), "some-partition-key-2"),
+                        Record("my-data-3".getBytes(), "some-partition-key-3"),
+                    ),
+                    Some(5),
+                    1.second
                 )
             } yield ExitCode.Success
         )

--- a/docs/smithy4s/getting-started.md
+++ b/docs/smithy4s/getting-started.md
@@ -65,6 +65,8 @@ This module provides an implementation of that interface, backed by the @:source
 
 
 ```scala mdoc:compile-only
+import scala.concurrent.duration._
+
 import cats.data.NonEmptyList
 import cats.effect._
 import cats.syntax.all._
@@ -95,6 +97,16 @@ object MyApp extends IOApp {
                             Record("my-data-2".getBytes(), "some-partition-key-2"),
                             Record("my-data-3".getBytes(), "some-partition-key-3"),
                         )
+                    )
+                    // Retries failed records with a configured limit and duration.
+                    _ <- producer.putWithRetry(
+                        NonEmptyList.of(
+                            Record("my-data".getBytes(), "some-partition-key"),
+                            Record("my-data-2".getBytes(), "some-partition-key-2"),
+                            Record("my-data-3".getBytes(), "some-partition-key-3"),
+                        ),
+                        Some(5),
+                        1.second
                     )
                 } yield ExitCode.Success
         )

--- a/kinesis-client/src/main/scala/kinesis4cats/client/producer/KinesisProducer.scala
+++ b/kinesis-client/src/main/scala/kinesis4cats/client/producer/KinesisProducer.scala
@@ -92,12 +92,14 @@ final class KinesisProducer[F[_]] private (
       resp: PutRecordsResponse
   ): Option[NonEmptyList[Producer.FailedRecord]] =
     NonEmptyList.fromList(
-      resp.records().asScala.toList.zip(records.toList).collect {
-        case (respEntry, record) if Option(respEntry.errorCode()).nonEmpty =>
+      resp.records().asScala.toList.zipWithIndex.zip(records.toList).collect {
+        case ((respEntry, respIndex), record)
+            if Option(respEntry.errorCode()).nonEmpty =>
           Producer.FailedRecord(
             record,
             respEntry.errorCode(),
-            respEntry.errorMessage()
+            respEntry.errorMessage(),
+            respIndex
           )
       }
     )

--- a/shared/src/main/scala/kinesis4cats/producer/Producer.scala
+++ b/shared/src/main/scala/kinesis4cats/producer/Producer.scala
@@ -204,7 +204,11 @@ abstract class Producer[F[_], PutReq, PutRes](implicit
       case x if x.isRight                                     => F.pure(x)
       case x if x.left.exists(e => e.errors.exists(_.isLeft)) => F.pure(x)
       case x if retries.exists(_ <= 0) =>
-        logger.debug(ctx.context)("All retries have been exhausted").as(x)
+        logger
+          .warn(ctx.context)(
+            "All retries have been exhausted, and the final retry detected errors"
+          )
+          .as(x)
       case x =>
         logger
           .debug(ctx.context)("Failures detected, retrying failed records")

--- a/shared/src/test/resources/logback-test.xml
+++ b/shared/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>[%thread] %highlight(%-5level) %d{ISO8601} %cyan(%logger{15}) %yellow(%mdc) - %msg %n</pattern>
+    </encoder>
+  </appender>
+  <logger name="kinesis4cats" level="ERROR"/>
+  <logger name="software.amazon.kinesis" level="ERROR"/>
+  <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="STDOUT" />
+  </appender>
+  <root level="ERROR">
+    <appender-ref ref="ASYNC" />
+  </root>
+</configuration>

--- a/shared/src/test/scala/kinesis4cats/producer/ProducerSpec.scala
+++ b/shared/src/test/scala/kinesis4cats/producer/ProducerSpec.scala
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2023-2023 etspaceman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kinesis4cats.producer
+
+import scala.concurrent.duration._
+
+import java.time.Instant
+
+import cats.Eq
+import cats.data.Ior
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.effect.Resource
+import cats.effect.SyncIO
+import cats.effect.syntax.all._
+import cats.syntax.all._
+import org.typelevel.log4cats.StructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+import kinesis4cats.instances.eq._
+import kinesis4cats.models.HashKeyRange
+import kinesis4cats.models.ShardId
+import kinesis4cats.models.StreamNameOrArn
+import kinesis4cats.producer.logging.instances.show._
+
+class ProducerSpec extends munit.CatsEffectSuite {
+  def fixture: SyncIO[FunFixture[MockProducer]] = ResourceFixture(
+    MockProducer()
+  )
+
+  fixture.test("It should retry methods and eventually produce") { producer =>
+    val record1 = Record(Array.fill(50)(1), "1")
+    val record2 = Record(Array.fill(50)(1), "2")
+    val record3 = Record(Array.fill(50)(1), "3")
+    val record4 = Record(Array.fill(50)(1), "4")
+    val record5 = Record(Array.fill(50)(1), "5")
+
+    val data = NonEmptyList.of(
+      record1,
+      record2,
+      record3,
+      record4,
+      record5
+    )
+
+    val failed1 = Producer.FailedRecord(
+      record2,
+      "ProvisionedThroughputExceededException",
+      "Throughput was exceeded",
+      1
+    )
+    val failed2 = Producer.FailedRecord(
+      record3,
+      "ProvisionedThroughputExceededException",
+      "Throughput was exceeded",
+      2
+    )
+    val failed3 = Producer.FailedRecord(
+      record4,
+      "ProvisionedThroughputExceededException",
+      "Throughput was exceeded",
+      3
+    )
+    val failed4 = Producer.FailedRecord(
+      record5,
+      "ProvisionedThroughputExceededException",
+      "Throughput was exceeded",
+      4
+    )
+
+    val response1 = MockPutResponse(
+      NonEmptyList.one(record1),
+      List(record2, record3, record4, record5)
+    )
+
+    val response2 = MockPutResponse(
+      NonEmptyList.one(record2),
+      List(record3, record4, record5)
+    )
+
+    val response3 = MockPutResponse(
+      NonEmptyList.one(record3),
+      List(record4, record5)
+    )
+
+    val response4 = MockPutResponse(
+      NonEmptyList.one(record4),
+      List(record5)
+    )
+
+    val response5 = MockPutResponse(
+      NonEmptyList.one(record5),
+      List.empty
+    )
+
+    val expected: Ior[Producer.Error, NonEmptyList[MockPutResponse]] = Ior.both(
+      Producer.Error(
+        Some(
+          Ior.Right(
+            NonEmptyList.of(
+              failed1,
+              failed2,
+              failed3,
+              failed4,
+              failed2,
+              failed3,
+              failed4,
+              failed3,
+              failed4,
+              failed4
+            )
+          )
+        )
+      ),
+      NonEmptyList.of(response1, response2, response3, response4, response5)
+    )
+
+    producer.putWithRetry(data, Some(5), 0.seconds).map { res =>
+      assert(res === expected)
+    }
+  }
+}
+
+class MockProducer(
+    val logger: StructuredLogger[IO],
+    val shardMapCache: ShardMapCache[IO],
+    val config: Producer.Config
+) extends Producer[IO, MockPutRequest, MockPutResponse] {
+
+  var requests: Int = 0 // scalafix:ok
+
+  override protected def putImpl(req: MockPutRequest): IO[MockPutResponse] =
+    for {
+      _ <- IO(this.requests = this.requests + 1)
+    } yield MockPutResponse(
+      NonEmptyList.one(req.records.head),
+      req.records.tail
+    )
+
+  override protected def asPutRequest(
+      records: NonEmptyList[Record]
+  ): MockPutRequest = MockPutRequest(records)
+
+  override protected def failedRecords(
+      records: NonEmptyList[Record],
+      resp: MockPutResponse
+  ): Option[NonEmptyList[Producer.FailedRecord]] = resp.failedRecords match {
+    case Nil => None
+    case x =>
+      Some(
+        NonEmptyList
+          .fromListUnsafe(x)
+          .zipWithIndex
+          .map { case (r, i) =>
+            Producer.FailedRecord(
+              r,
+              "ProvisionedThroughputExceededException",
+              "Throughput was exceeded",
+              i
+            )
+          }
+      )
+  }
+
+}
+
+object MockProducer {
+  def apply(): Resource[IO, MockProducer] = for {
+    logger <- Slf4jLogger.create[IO].toResource
+    shardMapCache <- ShardMapCache[IO](
+      ShardMapCache.Config.default,
+      IO.pure(
+        Right(
+          ShardMap(
+            List(
+              ShardMapRecord(
+                ShardId("1"),
+                HashKeyRange(BigInt("1"), BigInt("100"))
+              )
+            ),
+            Instant.now()
+          )
+        )
+      ),
+      Slf4jLogger.create[IO]
+    )
+    defaultConfig = Producer.Config.default(StreamNameOrArn.Name("foo"))
+  } yield new MockProducer(
+    logger,
+    shardMapCache,
+    defaultConfig.copy(batcherConfig =
+      defaultConfig.batcherConfig.copy(aggregate = false)
+    )
+  )
+}
+
+case class MockPutRequest(records: NonEmptyList[Record])
+
+case class MockPutResponse(
+    successRecords: NonEmptyList[Record],
+    failedRecords: List[Record]
+)
+
+object MockPutResponse {
+  implicit val mockPutResponseEq: Eq[MockPutResponse] = (x, y) =>
+    x.successRecords === y.successRecords &&
+      x.failedRecords === y.failedRecords
+}

--- a/smithy4s-client/src/main/scala/kinesis4cats/smithy4s/client/producer/KinesisProducer.scala
+++ b/smithy4s-client/src/main/scala/kinesis4cats/smithy4s/client/producer/KinesisProducer.scala
@@ -90,13 +90,14 @@ final class KinesisProducer[F[_]] private[kinesis4cats] (
       resp: PutRecordsOutput
   ): Option[NonEmptyList[Producer.FailedRecord]] =
     NonEmptyList.fromList(
-      resp.records.zip(records.toList).collect {
-        case (respEntry, record)
+      resp.records.zipWithIndex.zip(records.toList).collect {
+        case ((respEntry, index), record)
             if respEntry.errorCode.nonEmpty && respEntry.errorMessage.nonEmpty =>
           Producer.FailedRecord(
             record,
             respEntry.errorCode.get.value,
-            respEntry.errorMessage.get.value
+            respEntry.errorMessage.get.value,
+            index
           )
       }
     )


### PR DESCRIPTION
## Changes Introduced

Adds a retryable put method to the Producer, which detects failed records and retries only those records.

## Applicable linked issues

#16 

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [x] I have introduced tests for all new features and changes
- [x] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review