### PR TITLE
Graceful Producer Shutdown

### DIFF
--- a/integration-tests/src/test/scalajvm/kinesis4cats/kcl/KCLConsumerSpec.scala
+++ b/integration-tests/src/test/scalajvm/kinesis4cats/kcl/KCLConsumerSpec.scala
@@ -19,7 +19,7 @@ package kcl
 
 import scala.concurrent.duration._
 
-import cats.effect.kernel.Deferred
+import cats.effect.Deferred
 import cats.effect.std.Queue
 import cats.effect.{IO, Resource, SyncIO}
 import cats.syntax.all._

--- a/integration-tests/src/test/scalajvm/kinesis4cats/kcl/fs2/KCLConsumerFS2Spec.scala
+++ b/integration-tests/src/test/scalajvm/kinesis4cats/kcl/fs2/KCLConsumerFS2Spec.scala
@@ -21,7 +21,7 @@ package fs2
 import scala.concurrent.duration._
 
 import _root_.fs2.Stream
-import cats.effect.kernel.Deferred
+import cats.effect.Deferred
 import cats.effect.{IO, Resource, SyncIO}
 import cats.syntax.all._
 import io.circe.parser._

--- a/integration-tests/src/test/scalajvm/kinesis4cats/kcl/fs2/multistream/KCLConsumerFS2MultiSpec.scala
+++ b/integration-tests/src/test/scalajvm/kinesis4cats/kcl/fs2/multistream/KCLConsumerFS2MultiSpec.scala
@@ -20,7 +20,7 @@ package kcl.fs2.multistream
 import scala.concurrent.duration._
 
 import _root_.fs2.Stream
-import cats.effect.kernel.Deferred
+import cats.effect.Deferred
 import cats.effect.syntax.all._
 import cats.effect.{IO, Resource, SyncIO}
 import cats.syntax.all._

--- a/integration-tests/src/test/scalajvm/kinesis4cats/kcl/multistream/KCLConsumerMultiSpec.scala
+++ b/integration-tests/src/test/scalajvm/kinesis4cats/kcl/multistream/KCLConsumerMultiSpec.scala
@@ -20,7 +20,7 @@ package multistream
 
 import scala.concurrent.duration._
 
-import cats.effect.kernel.Deferred
+import cats.effect.Deferred
 import cats.effect.std.Queue
 import cats.effect.syntax.all._
 import cats.effect.{IO, Resource, SyncIO}

--- a/integration-tests/src/test/scalajvm/kinesis4cats/smithy4s/client/KinesisClientJVMSpec.scala
+++ b/integration-tests/src/test/scalajvm/kinesis4cats/smithy4s/client/KinesisClientJVMSpec.scala
@@ -16,9 +16,9 @@
 
 package kinesis4cats.smithy4s.client
 
+import cats.effect.Async
 import cats.effect.IO
 import cats.effect.SyncIO
-import cats.effect.kernel.Async
 import com.amazonaws.kinesis.Kinesis
 import org.http4s.blaze.client.BlazeClientBuilder
 

--- a/kcl/src/main/scala/kinesis4cats/kcl/KCLConsumer.scala
+++ b/kcl/src/main/scala/kinesis4cats/kcl/KCLConsumer.scala
@@ -16,7 +16,7 @@
 
 package kinesis4cats.kcl
 
-import cats.effect.kernel.Deferred
+import cats.effect.Deferred
 import cats.effect.syntax.all._
 import cats.effect.{Async, Ref, Resource}
 import cats.syntax.all._

--- a/kcl/src/main/scala/kinesis4cats/kcl/fs2/KCLConsumerFS2.scala
+++ b/kcl/src/main/scala/kinesis4cats/kcl/fs2/KCLConsumerFS2.scala
@@ -19,7 +19,7 @@ package kinesis4cats.kcl.fs2
 import scala.concurrent.duration._
 
 import cats.Parallel
-import cats.effect.kernel.Deferred
+import cats.effect.Deferred
 import cats.effect.std.Queue
 import cats.effect.syntax.all._
 import cats.effect.{Async, Ref, Resource}

--- a/kinesis-client/src/main/scala/kinesis4cats/client/producer/KinesisProducer.scala
+++ b/kinesis-client/src/main/scala/kinesis4cats/client/producer/KinesisProducer.scala
@@ -22,8 +22,8 @@ import scala.jdk.CollectionConverters._
 import java.time.Instant
 
 import cats.data.NonEmptyList
+import cats.effect.Resource
 import cats.effect._
-import cats.effect.kernel.Resource
 import cats.effect.syntax.all._
 import cats.syntax.all._
 import org.typelevel.log4cats.StructuredLogger

--- a/kpl-ciris/src/main/scala/kinesis4cats/kpl/ciris/KPLCiris.scala
+++ b/kpl-ciris/src/main/scala/kinesis4cats/kpl/ciris/KPLCiris.scala
@@ -21,7 +21,7 @@ import scala.concurrent.duration._
 
 import _root_.ciris._
 import cats.effect.Async
-import cats.effect.kernel.Resource
+import cats.effect.Resource
 import cats.syntax.all._
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.regions.Regions

--- a/smithy4s-client-localstack/src/main/scala/kinesis4cats/smithy4s/client/localstack/LocalstackKinesisClient.scala
+++ b/smithy4s-client-localstack/src/main/scala/kinesis4cats/smithy4s/client/localstack/LocalstackKinesisClient.scala
@@ -20,7 +20,7 @@ package localstack
 import scala.concurrent.duration._
 
 import cats.effect.Async
-import cats.effect.kernel.Resource
+import cats.effect.Resource
 import cats.effect.syntax.all._
 import cats.syntax.all._
 import com.amazonaws.kinesis._

--- a/smithy4s-client/src/main/scala/kinesis4cats/smithy4s/client/middleware/RequestResponseLogger.scala
+++ b/smithy4s-client/src/main/scala/kinesis4cats/smithy4s/client/middleware/RequestResponseLogger.scala
@@ -16,7 +16,7 @@
 
 package kinesis4cats.smithy4s.client.middleware
 
-import cats.effect.kernel.Async
+import cats.effect.Async
 import org.http4s.client.Client
 import org.typelevel.log4cats.StructuredLogger
 

--- a/smithy4s-client/src/main/scala/kinesis4cats/smithy4s/client/producer/KinesisProducer.scala
+++ b/smithy4s-client/src/main/scala/kinesis4cats/smithy4s/client/producer/KinesisProducer.scala
@@ -20,8 +20,8 @@ package producer
 import java.time.Instant
 
 import cats.data.NonEmptyList
+import cats.effect.Resource
 import cats.effect._
-import cats.effect.kernel.Resource
 import cats.effect.syntax.all._
 import cats.syntax.all._
 import com.amazonaws.kinesis._

--- a/smithy4s-client/src/main/scala/kinesis4cats/smithy4s/client/producer/fs2/FS2KinesisProducer.scala
+++ b/smithy4s-client/src/main/scala/kinesis4cats/smithy4s/client/producer/fs2/FS2KinesisProducer.scala
@@ -18,9 +18,8 @@ package kinesis4cats.smithy4s.client
 package producer
 package fs2
 
-import cats.effect.Async
-import cats.effect.kernel.Resource
-import cats.effect.std.Queue
+import _root_.fs2.concurrent.Channel
+import cats.effect._
 import cats.effect.syntax.all._
 import com.amazonaws.kinesis.PutRecordsInput
 import com.amazonaws.kinesis.PutRecordsOutput
@@ -40,9 +39,9 @@ import kinesis4cats.producer.fs2.FS2Producer
   *
   * @param config
   *   [[kinesis.producer.fs2.FS2Producer.Config FS2Producer.Config]]
-  * @param queue
-  *   [[cats.effect.std.Queue Queue]] of
-  *   [[kinesis4cats.producer.Record Records]] to produce.
+  * @param channel
+  *   [[https://github.com/typelevel/fs2/blob/main/core/shared/src/main/scala/fs2/concurrent/Channel.scala Channel]]
+  *   of [[kinesis4cats.producer.Record Records]] to produce.
   * @param underlying
   *   [[kinesis4cats.smithy4s.client.producer.KinesisProducer KinesisProducer]]
   * @param callback:
@@ -55,7 +54,7 @@ import kinesis4cats.producer.fs2.FS2Producer
 final class FS2KinesisProducer[F[_]] private[kinesis4cats] (
     override val logger: StructuredLogger[F],
     override val config: FS2Producer.Config,
-    override protected val queue: Queue[F, Option[Record]],
+    override protected val channel: Channel[F, Record],
     override protected val underlying: KinesisProducer[F]
 )(
     override protected val callback: (
@@ -131,11 +130,10 @@ object FS2KinesisProducer {
       loggerF,
       credsF
     )
-    queue <- Queue.bounded[F, Option[Record]](config.queueSize).toResource
-    producer = new FS2KinesisProducer[F](logger, config, queue, underlying)(
+    channel <- Channel.bounded[F, Record](config.queueSize).toResource
+    producer = new FS2KinesisProducer[F](logger, config, channel, underlying)(
       callback
     )
-    _ <- producer.start()
-    _ <- Resource.onFinalize(producer.stop())
+    _ <- producer.resource
   } yield producer
 }


### PR DESCRIPTION
## Changes Introduced

Leverages an FS2 Channel to handle the graceful shutdown for Producer interfaces

## Applicable linked issues

## Checklist (check all that apply)

- [X] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review