### PR TITLE
Use FS2 Streams for responses to SubscribeToShard + Paginated Requests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -221,7 +221,8 @@ lazy val `kinesis-client` = projectMatrix
       Aws.V2.kinesis,
       Aws.V2.dynamo,
       Aws.V2.cloudwatch,
-      Log4Cats.slf4j
+      Log4Cats.slf4j,
+      FS2.reactiveStreams
     )
   )
   .jvmPlatform(allScalaVersions)

--- a/docs/client/localstack.md
+++ b/docs/client/localstack.md
@@ -19,9 +19,6 @@ import kinesis4cats.client.producer.localstack.LocalstackKinesisProducer
 import kinesis4cats.client.producer.fs2.localstack.LocalstackFS2KinesisProducer
 import kinesis4cats.producer.logging.instances.show._
 
-// Load a KinesisClient as an effect
-LocalstackKinesisClient.client[IO]()
-
 // Load a KinesisClient as a Resource
 LocalstackKinesisClient.clientResource[IO]()
 

--- a/integration-tests/src/test/resources/logback-test.xml
+++ b/integration-tests/src/test/resources/logback-test.xml
@@ -4,8 +4,8 @@
       <pattern>[%thread] %highlight(%-5level) %d{ISO8601} %cyan(%logger{15}) %yellow(%mdc) - %msg %n</pattern>
     </encoder>
   </appender>
-  <logger name="kinesis4cats" level="ERROR"/>
-  <logger name="software.amazon.kinesis" level="ERROR"/>
+  <logger name="kinesis4cats" level="DEBUG"/>
+  <logger name="software.amazon" level="DEBUG"/>
   <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
     <appender-ref ref="STDOUT" />
   </appender>

--- a/integration-tests/src/test/resources/logback-test.xml
+++ b/integration-tests/src/test/resources/logback-test.xml
@@ -4,8 +4,8 @@
       <pattern>[%thread] %highlight(%-5level) %d{ISO8601} %cyan(%logger{15}) %yellow(%mdc) - %msg %n</pattern>
     </encoder>
   </appender>
-  <logger name="kinesis4cats" level="DEBUG"/>
-  <logger name="software.amazon" level="DEBUG"/>
+  <logger name="kinesis4cats" level="ERROR"/>
+  <logger name="software.amazon" level="ERROR"/>
   <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
     <appender-ref ref="STDOUT" />
   </appender>

--- a/integration-tests/src/test/scalajvm/kinesis4cats/client/KinesisClientSpec.scala
+++ b/integration-tests/src/test/scalajvm/kinesis4cats/client/KinesisClientSpec.scala
@@ -212,7 +212,6 @@ class KinesisClientSpec extends munit.CatsEffectSuite {
             )
             .build()
         )
-        .evalTap(x => IO.println(s"Received SubscribeToShardEvent: $x"))
         .take(3)
         .compile
         .toList
@@ -294,7 +293,7 @@ class KinesisClientSpec extends munit.CatsEffectSuite {
       assertEquals(List(record1, record2, record3), recordsParsed2)
       assert(consumers.consumers().size() === 1)
       assert(consumers2.head.consumers().size() === 1)
-      /*assertEquals(
+      assertEquals(
         streams.streamNames().asScala.toList,
         List(streamName, "test-kcl-service-stream")
       )
@@ -305,7 +304,7 @@ class KinesisClientSpec extends munit.CatsEffectSuite {
       assertEquals(
         streams3.flatMap(_.streamNames().asScala.toList),
         List(streamName, "test-kcl-service-stream")
-      )*/
+      )
       assertEquals(
         tags.tags().asScala.toList.map(x => (x.key(), x.value())),
         List("foo" -> "bar")

--- a/kinesis-client-localstack/src/main/scala/kinesis4cats/client/localstack/LocalstackKinesisClient.scala
+++ b/kinesis-client-localstack/src/main/scala/kinesis4cats/client/localstack/LocalstackKinesisClient.scala
@@ -20,6 +20,7 @@ package localstack
 import scala.concurrent.duration._
 
 import cats.effect.std.Dispatcher
+import cats.effect.std.Supervisor
 import cats.effect.syntax.all._
 import cats.effect.{Async, Resource}
 import cats.syntax.all._
@@ -30,7 +31,6 @@ import kinesis4cats.compat.retry.RetryPolicies._
 import kinesis4cats.compat.retry._
 import kinesis4cats.localstack.LocalstackConfig
 import kinesis4cats.localstack.aws.v2.AwsClients
-import cats.effect.std.Supervisor
 
 object LocalstackKinesisClient {
 

--- a/kinesis-client-localstack/src/main/scala/kinesis4cats/client/localstack/LocalstackKinesisClient.scala
+++ b/kinesis-client-localstack/src/main/scala/kinesis4cats/client/localstack/LocalstackKinesisClient.scala
@@ -19,6 +19,7 @@ package localstack
 
 import scala.concurrent.duration._
 
+import cats.effect.std.Dispatcher
 import cats.effect.syntax.all._
 import cats.effect.{Async, Resource}
 import cats.syntax.all._
@@ -29,48 +30,9 @@ import kinesis4cats.compat.retry.RetryPolicies._
 import kinesis4cats.compat.retry._
 import kinesis4cats.localstack.LocalstackConfig
 import kinesis4cats.localstack.aws.v2.AwsClients
+import cats.effect.std.Supervisor
 
 object LocalstackKinesisClient {
-
-  /** Builds a [[kinesis4cats.client.KinesisClient KinesisClient]] that is
-    * compliant for Localstack usage.
-    *
-    * @param config
-    *   [[kinesis4cats.localstack.LocalstackConfig LocalstackConfig]]
-    * @param F
-    *   F with an [[cats.effect.Async Async]] instance
-    * @param LE
-    *   [[kinesis4cats.client.KinesisClient.LogEncoders LogEncoders]]
-    * @return
-    *   F of [[kinesis4cats.client.KinesisClient KinesisClient]]
-    */
-  def client[F[_]](
-      config: LocalstackConfig
-  )(implicit F: Async[F], LE: KinesisClient.LogEncoders): F[KinesisClient[F]] =
-    for {
-      underlying <- AwsClients.kinesisClient(config)
-      logger <- Slf4jLogger.create[F]
-    } yield new KinesisClient(underlying, logger)
-
-  /** Builds a [[kinesis4cats.client.KinesisClient KinesisClient]] that is
-    * compliant for Localstack usage.
-    *
-    * @param prefix
-    *   Optional prefix for parsing configuration. Default to None
-    * @param F
-    *   F with an [[cats.effect.Async Async]] instance
-    * @param LE
-    *   [[kinesis4cats.client.KinesisClient.LogEncoders LogEncoders]]
-    * @return
-    *   F of [[kinesis4cats.client.KinesisClient KinesisClient]]
-    */
-  def client[F[_]](
-      prefix: Option[String] = None
-  )(implicit F: Async[F], LE: KinesisClient.LogEncoders): F[KinesisClient[F]] =
-    for {
-      underlying <- AwsClients.kinesisClient(prefix)
-      logger <- Slf4jLogger.create[F]
-    } yield new KinesisClient(underlying, logger)
 
   /** Builds a [[kinesis4cats.client.KinesisClient KinesisClient]] that is
     * compliant for Localstack usage. Lifecycle is managed as a
@@ -89,8 +51,12 @@ object LocalstackKinesisClient {
   def clientResource[F[_]](config: LocalstackConfig)(implicit
       F: Async[F],
       LE: KinesisClient.LogEncoders
-  ): Resource[F, KinesisClient[F]] =
-    client[F](config).toResource
+  ): Resource[F, KinesisClient[F]] = for {
+    underlying <- AwsClients.kinesisClient(config).toResource
+    logger <- Slf4jLogger.create[F].toResource
+    dispatcher <- Dispatcher.parallel[F]
+    supervisor <- Supervisor[F]
+  } yield new KinesisClient(underlying, logger, dispatcher, supervisor)
 
   /** Builds a [[kinesis4cats.client.KinesisClient KinesisClient]] that is
     * compliant for Localstack usage. Lifecycle is managed as a
@@ -110,7 +76,7 @@ object LocalstackKinesisClient {
       F: Async[F],
       LE: KinesisClient.LogEncoders
   ): Resource[F, KinesisClient[F]] =
-    client[F](prefix).toResource
+    LocalstackConfig.resource(prefix).flatMap(clientResource[F])
 
   /** A resources that does the following:
     *

--- a/kinesis-client-localstack/src/main/scala/kinesis4cats/client/localstack/LocalstackKinesisClient.scala
+++ b/kinesis-client-localstack/src/main/scala/kinesis4cats/client/localstack/LocalstackKinesisClient.scala
@@ -20,7 +20,6 @@ package localstack
 import scala.concurrent.duration._
 
 import cats.effect.std.Dispatcher
-import cats.effect.std.Supervisor
 import cats.effect.syntax.all._
 import cats.effect.{Async, Resource}
 import cats.syntax.all._
@@ -55,8 +54,7 @@ object LocalstackKinesisClient {
     underlying <- AwsClients.kinesisClient(config).toResource
     logger <- Slf4jLogger.create[F].toResource
     dispatcher <- Dispatcher.parallel[F]
-    supervisor <- Supervisor[F]
-  } yield new KinesisClient(underlying, logger, dispatcher, supervisor)
+  } yield new KinesisClient(underlying, logger, dispatcher)
 
   /** Builds a [[kinesis4cats.client.KinesisClient KinesisClient]] that is
     * compliant for Localstack usage. Lifecycle is managed as a

--- a/kinesis-client-logging-circe/src/main/scala/kinesis4cats/client/logging/instances/circe.scala
+++ b/kinesis-client-logging-circe/src/main/scala/kinesis4cats/client/logging/instances/circe.scala
@@ -930,6 +930,25 @@ object circe {
       Json.obj(fields.toSeq: _*)
     }
 
+  implicit val sdkEventTypeEncoder
+      : Encoder[kin.SubscribeToShardEventStream.EventType] =
+    Encoder[String].contramap(_.toString())
+
+  implicit val subscribeToShardEventEncoder
+      : Encoder[kin.SubscribeToShardEvent] = x => {
+    val fields: Map[String, Json] = Map
+      .empty[String, Json]
+      .safeAdd("childShards", x.childShards())
+      .safeAdd("continuationSequenceNumber", x.continuationSequenceNumber())
+      .safeAdd("hasChildShards", x.hasChildShards())
+      .safeAdd("hasRecords", x.hasRecords())
+      .safeAdd("millisBehindLatest", x.millisBehindLatest())
+      .safeAdd("records", x.records())
+      .safeAdd("sdkEventType", x.sdkEventType())
+
+    Json.obj(fields.toSeq: _*)
+  }
+
   implicit val kinesisClientLogEncoders: KinesisClient.LogEncoders =
     new KinesisClient.LogEncoders()
 

--- a/kinesis-client/src/main/scala/kinesis4cats/client/KinesisClient.scala
+++ b/kinesis-client/src/main/scala/kinesis4cats/client/KinesisClient.scala
@@ -18,14 +18,18 @@ package kinesis4cats.client
 
 import java.util.concurrent.CompletableFuture
 
+import cats.effect.std.Dispatcher
+import cats.effect.std.Supervisor
 import cats.effect.syntax.all._
 import cats.effect.{Async, Resource}
 import cats.syntax.all._
+import fs2.Stream
+import fs2.interop.reactivestreams._
 import org.typelevel.log4cats.StructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import software.amazon.awssdk.core.async.SdkPublisher
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
 import software.amazon.awssdk.services.kinesis.model._
-import software.amazon.awssdk.services.kinesis.paginators._
 
 import kinesis4cats.logging.{LogContext, LogEncoder}
 
@@ -45,7 +49,9 @@ import kinesis4cats.logging.{LogContext, LogEncoder}
   */
 class KinesisClient[F[_]] private[kinesis4cats] (
     val client: KinesisAsyncClient,
-    logger: StructuredLogger[F]
+    logger: StructuredLogger[F],
+    dispatcher: Dispatcher[F],
+    supervisor: Supervisor[F]
 )(implicit
     F: Async[F],
     LE: KinesisClient.LogEncoders
@@ -88,22 +94,6 @@ class KinesisClient[F[_]] private[kinesis4cats] (
     } yield response
   }
 
-  private def runVoidRequest[A: LogEncoder](
-      method: String,
-      request: A
-  )(fn: (KinesisAsyncClient, A) => CompletableFuture[Void]): F[Unit] = {
-    val ctx = LogContext()
-    for {
-      _ <- requestLogs(method, request, ctx)
-      response <- F
-        .fromCompletableFuture(
-          F.delay(fn(client, request))
-        )
-        .void
-      _ <- responseLogs(method, "no response object", ctx)
-    } yield response
-  }
-
   private def runRequest[A: LogEncoder](
       method: String
   )(fn: KinesisAsyncClient => CompletableFuture[A]): F[A] = {
@@ -120,23 +110,23 @@ class KinesisClient[F[_]] private[kinesis4cats] (
   private def runPaginatedRequest[A: LogEncoder, B](
       method: String,
       request: A
-  )(fn: (KinesisAsyncClient, A) => B): F[B] = {
+  )(fn: (KinesisAsyncClient, A) => SdkPublisher[B]): Stream[F, B] = {
     val ctx = LogContext()
     for {
-      _ <- requestLogs(method, request, ctx)
-      response <- F.delay(fn(client, request))
-      _ <- responseLogs(method, "paginated response object", ctx)
+      _ <- Stream.eval(requestLogs(method, request, ctx))
+      response <- fn(client, request).toStreamBuffered(16)
+      _ <- Stream.eval(responseLogs(method, "paginated response object", ctx))
     } yield response
   }
 
   private def runPaginatedRequest[A](
       method: String
-  )(fn: KinesisAsyncClient => A): F[A] = {
+  )(fn: KinesisAsyncClient => SdkPublisher[A]): Stream[F, A] = {
     val ctx = LogContext()
     for {
-      _ <- requestLogs(method, "no request", ctx)
-      response <- F.delay(fn(client))
-      _ <- responseLogs(method, "paginated response object", ctx)
+      _ <- Stream.eval(requestLogs(method, "no request", ctx))
+      response <- fn(client).toStreamBuffered(16)
+      _ <- Stream.eval(responseLogs(method, "paginated response object", ctx))
     } yield response
   }
 
@@ -229,7 +219,7 @@ class KinesisClient[F[_]] private[kinesis4cats] (
 
   def listStreamConsumersPaginator(
       request: ListStreamConsumersRequest
-  ): F[ListStreamConsumersPublisher] =
+  ): Stream[F, ListStreamConsumersResponse] =
     runPaginatedRequest("listStreamConsumersPaginator", request)(
       _.listStreamConsumersPaginator(_)
     )
@@ -242,12 +232,12 @@ class KinesisClient[F[_]] private[kinesis4cats] (
 
   def listStreamsPaginator(
       request: ListStreamsRequest
-  ): F[ListStreamsPublisher] =
+  ): Stream[F, ListStreamsResponse] =
     runPaginatedRequest("listStreamsPaginator", request)(
       _.listStreamsPaginator(_)
     )
 
-  def listStreamsPaginator(): F[ListStreamsPublisher] =
+  def listStreamsPaginator(): Stream[F, ListStreamsResponse] =
     runPaginatedRequest("listStreamsPaginator")(
       _.listStreamsPaginator()
     )
@@ -290,12 +280,32 @@ class KinesisClient[F[_]] private[kinesis4cats] (
     runRequest("stopStreamEncryption", request)(_.stopStreamEncryption(_))
 
   def subscribeToShard(
-      request: SubscribeToShardRequest,
-      responseHandler: SubscribeToShardResponseHandler
-  ): F[Unit] =
-    runVoidRequest("subscribeToShard", request)(
-      _.subscribeToShard(_, responseHandler)
-    )
+      request: SubscribeToShardRequest
+  ): Stream[F, SubscribeToShardEvent] = {
+    val ctx = LogContext()
+    for {
+      _ <- Stream.eval(requestLogs("subscribeToShard", request, ctx))
+      handler <- Stream.eval(SubscribeToShardHandler[F](dispatcher))
+      _ <- Stream.eval(
+        supervisor.supervise(
+          F.fromCompletableFuture(
+            F.delay(client.subscribeToShard(request, handler))
+          )
+        )
+      )
+      publisher <- Stream.eval(handler.deferredPublisher.get)
+      stream <- publisher
+        .toStreamBuffered(16)
+        .evalTap(x =>
+          logger.debug(ctx.context)(s"Received SubscribeToShardEvent: $x")
+        )
+        .interruptWhen(handler.deferredComplete)
+        .flatMap {
+          case x: SubscribeToShardEvent => Stream.emit(x)
+          case _                        => Stream.empty
+        }
+    } yield stream
+  }
 
   def updateShardCount(
       request: UpdateShardCountRequest
@@ -331,7 +341,9 @@ object KinesisClient {
   ): Resource[F, KinesisClient[F]] = for {
     clientResource <- Resource.fromAutoCloseable(F.pure(client))
     logger <- Slf4jLogger.create[F].toResource
-  } yield new KinesisClient[F](clientResource, logger)
+    dispatcher <- Dispatcher.parallel[F]
+    supervisor <- Supervisor[F]
+  } yield new KinesisClient[F](clientResource, logger, dispatcher, supervisor)
 
   /** Helper class containing required
     * [[kinesis4cats.logging.LogEncoder LogEncoders]] for the

--- a/kinesis-client/src/main/scala/kinesis4cats/client/KinesisClient.scala
+++ b/kinesis-client/src/main/scala/kinesis4cats/client/KinesisClient.scala
@@ -287,48 +287,45 @@ class KinesisClient[F[_]] private[kinesis4cats] (
     for {
       _ <- Stream.eval(requestLogs("subscribeToShard", request, ctx))
       handler <- Stream.eval(SubscribeToShardHandler[F](dispatcher))
-      initialize = Stream.eval(
+      _ <- Stream.resource(
         F.fromCompletableFuture(
           F.delay(client.subscribeToShard(request, handler))
         ).void
           .handleErrorWith(e => handler.deferredComplete.complete(Left(e)).void)
+          .background
       )
-      subscribe = Stream
-        .eval(handler.deferredPublisher.get)
-        .flatMap(publisher =>
-          publisher
-            .toStreamBuffered(1)
-            .flatMap {
-              case x: SubscribeToShardEvent => Stream.emit(x)
-              case _                        => Stream.empty
-            }
-            .evalTap(x =>
-              for {
-                _ <- logger
-                  .debug(ctx.context)(s"Received SubscribeToShardEvent")
-                _ <- logger.trace(
-                  ctx.addEncoded("subscribeToShardEvent", x).context
-                )(s"Logging SubscribeToShardEvent data")
-              } yield ()
-            )
-            .interruptWhen(handler.deferredComplete)
-            .onFinalize(
-              for {
-                complete <- handler.deferredComplete.tryGet
-                _ <- complete.traverse {
-                  case Left(e) =>
-                    Option(e.getCause()) match {
-                      case Some(x: SdkCancellationException) =>
-                        logger.debug(ctx.context)(x.getMessage())
-                      case _ =>
-                        F.raiseError[Unit](e)
-                    }
-                  case Right(_) => F.unit
-                }
-              } yield ()
-            )
+      publisher <- Stream.eval(handler.deferredPublisher.get)
+      stream <- publisher
+        .toStreamBuffered(1)
+        .flatMap {
+          case x: SubscribeToShardEvent => Stream.emit(x)
+          case _                        => Stream.empty
+        }
+        .evalTap(x =>
+          for {
+            _ <- logger
+              .debug(ctx.context)(s"Received SubscribeToShardEvent")
+            _ <- logger.trace(
+              ctx.addEncoded("subscribeToShardEvent", x).context
+            )(s"Logging SubscribeToShardEvent data")
+          } yield ()
         )
-      stream <- subscribe.concurrently(initialize)
+        .interruptWhen(handler.deferredComplete)
+        .onFinalize(
+          for {
+            complete <- handler.deferredComplete.tryGet
+            _ <- complete.traverse {
+              case Left(e) =>
+                Option(e.getCause()) match {
+                  case Some(x: SdkCancellationException) =>
+                    logger.debug(ctx.context)(x.getMessage())
+                  case _ =>
+                    F.raiseError[Unit](e)
+                }
+              case Right(_) => F.unit
+            }
+          } yield ()
+        )
     } yield stream
   }
 

--- a/kinesis-client/src/main/scala/kinesis4cats/client/SubscribeToShardHandler.scala
+++ b/kinesis-client/src/main/scala/kinesis4cats/client/SubscribeToShardHandler.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023-2023 etspaceman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kinesis4cats.client
+
+import cats.effect.Async
+import cats.effect.Deferred
+import cats.effect.std.Dispatcher
+import cats.syntax.all._
+import org.typelevel.log4cats.StructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import software.amazon.awssdk.core.async.SdkPublisher
+import software.amazon.awssdk.services.kinesis.model.SubscribeToShardEventStream
+import software.amazon.awssdk.services.kinesis.model.SubscribeToShardResponse
+import software.amazon.awssdk.services.kinesis.model.SubscribeToShardResponseHandler
+
+import kinesis4cats.logging.LogContext
+
+private[kinesis4cats] class SubscribeToShardHandler[F[_]](
+    dispatcher: Dispatcher[F],
+    logger: StructuredLogger[F],
+    val deferredResponse: Deferred[F, SubscribeToShardResponse],
+    val deferredComplete: Deferred[F, Either[Throwable, Unit]],
+    val deferredPublisher: Deferred[F, SdkPublisher[
+      SubscribeToShardEventStream
+    ]]
+)(implicit F: Async[F])
+    extends SubscribeToShardResponseHandler {
+
+  override def responseReceived(response: SubscribeToShardResponse): Unit =
+    dispatcher.unsafeRunSync(
+      logger.debug(LogContext().context)(s"Received response $response") >>
+        deferredResponse.complete(response).void
+    )
+
+  override def onEventStream(
+      publisher: SdkPublisher[SubscribeToShardEventStream]
+  ): Unit =
+    dispatcher.unsafeRunSync(
+      logger.debug(LogContext().context)(s"Received event stream") >>
+        deferredPublisher.complete(publisher).void
+    )
+
+  override def exceptionOccurred(throwable: Throwable): Unit =
+    dispatcher.unsafeRunSync(
+      logger.error(LogContext().context, throwable)(
+        s"Exception received in SubscribeToShardHandler"
+      ) >>
+        deferredComplete.complete(Left(throwable)).void
+    )
+
+  override def complete(): Unit =
+    dispatcher.unsafeRunSync(
+      logger.debug(LogContext().context)(s"Complete received") >>
+        deferredComplete.complete(Right(())).void
+    )
+}
+
+private[kinesis4cats] object SubscribeToShardHandler {
+  def apply[F[_]](
+      dispatcher: Dispatcher[F]
+  )(implicit F: Async[F]): F[SubscribeToShardHandler[F]] = for {
+    deferredResponse <- Deferred[F, SubscribeToShardResponse]
+    deferredComplete <- Deferred[F, Either[Throwable, Unit]]
+    deferredPublisher <- Deferred[F, SdkPublisher[SubscribeToShardEventStream]]
+    logger <- Slf4jLogger.create[F]
+  } yield new SubscribeToShardHandler(
+    dispatcher,
+    logger,
+    deferredResponse,
+    deferredComplete,
+    deferredPublisher
+  )
+}

--- a/kinesis-client/src/main/scala/kinesis4cats/client/SubscribeToShardHandler.scala
+++ b/kinesis-client/src/main/scala/kinesis4cats/client/SubscribeToShardHandler.scala
@@ -58,6 +58,7 @@ private[kinesis4cats] class SubscribeToShardHandler[F[_]](
   override def exceptionOccurred(throwable: Throwable): Unit =
     dispatcher.unsafeRunSync(
       (Option(throwable.getCause()) match {
+        // These are safe to simply debug, they will be raised if needed in the client
         case Some(x: SdkCancellationException) =>
           logger.debug(LogContext().context)(x.getMessage())
         case _ =>

--- a/kinesis-client/src/main/scala/kinesis4cats/client/logging/instances/show.scala
+++ b/kinesis-client/src/main/scala/kinesis4cats/client/logging/instances/show.scala
@@ -657,6 +657,20 @@ object show {
         .add("responseMetadata", x.responseMetadata())
         .build
 
+  implicit val sdkEventTypeShow
+      : Show[kin.SubscribeToShardEventStream.EventType] = Show.fromToString
+
+  implicit val subscribeToShardEventShow: Show[kin.SubscribeToShardEvent] = x =>
+    ShowBuilder("SubscribeToShardEvent")
+      .add("childShards", x.childShards())
+      .add("continuationSequenceNumber", x.continuationSequenceNumber())
+      .add("hasChildShards", x.hasChildShards())
+      .add("hasRecords", x.hasRecords())
+      .add("millisBehindLatest", x.millisBehindLatest())
+      .add("records", x.records())
+      .add("sdkEventType", x.sdkEventType())
+      .build
+
   implicit val kinesisClientLogEncoders: KinesisClient.LogEncoders =
     new KinesisClient.LogEncoders()
 


### PR DESCRIPTION
## Changes Introduced

Matching the approach of zio-aws, kinesis4cats will now return streamy API calls as, well, streams. 😄 .

This also adds coverage for the client project around the subscribeToShard API. While this isn't supported
directly by kinesis-mock, localstack has exposed functionality for it.

This is needed for developing an EnhancedFanOut consumer.

## Applicable linked issues

#17 

## Checklist (check all that apply)

- [ ] This change maintains backwards compatibility
- [X] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review