### PR TITLE
Drop smithy files from smithy4s-client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -124,7 +124,6 @@ lazy val kcl = projectMatrix
   .dependsOn(shared, `kinesis-client`)
 
 lazy val `kcl-http4s` = projectMatrix
-  .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
     description := "Http4s interfaces for the KCL",
     libraryDependencies ++= Seq(
@@ -277,6 +276,7 @@ lazy val `smithy4s-client` = projectMatrix
       (`smithy4s-client-transformers`.jvm(
         Scala212
       ) / Compile / packageBin).value,
+    Compile / smithy4sSmithyLibrary := false,
     scalacOptions -= "-deprecation"
   )
   .jvmPlatform(last2ScalaVersions)
@@ -285,7 +285,6 @@ lazy val `smithy4s-client` = projectMatrix
   .dependsOn(shared)
 
 lazy val `smithy4s-client-logging-circe` = projectMatrix
-  .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
     description := "JSON structured logging instances for the Smithy4s Kinesis Client, via Circe",
     libraryDependencies ++= Seq(Http4s.circe.value)

--- a/build.sbt
+++ b/build.sbt
@@ -124,6 +124,7 @@ lazy val kcl = projectMatrix
   .dependsOn(shared, `kinesis-client`)
 
 lazy val `kcl-http4s` = projectMatrix
+  .enablePlugins(Smithy4sCodegenPlugin)
   .settings(
     description := "Http4s interfaces for the KCL",
     libraryDependencies ++= Seq(
@@ -131,7 +132,8 @@ lazy val `kcl-http4s` = projectMatrix
       "com.disneystreaming.smithy4s" %%% "smithy4s-http4s" % smithy4sVersion.value,
       "com.disneystreaming.smithy4s" %%% "smithy4s-http4s-swagger" % smithy4sVersion.value,
       Http4s.emberServer.value
-    )
+    ),
+    Compile / smithy4sSmithyLibrary := false
   )
   .jvmPlatform(allScalaVersions)
   .dependsOn(kcl)


### PR DESCRIPTION
## Changes Introduced

- remove smithy4s codegen plugin from modules that don't need it
- make `smithy4s-client` a non-smithy-library. This will result in the jar not containing a Smithy manifest and copies of the codegen sources.

Jar contents before:

<img width="716" alt="image" src="https://user-images.githubusercontent.com/894884/232140747-cfb07451-4174-495a-b866-e71bec8e2e37.png">

Jar contents after:

<img width="633" alt="image" src="https://user-images.githubusercontent.com/894884/232140808-ed3da07e-653c-4863-ae8f-59ed0a1ea889.png">


## Applicable linked issues

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [x] I have introduced tests for all new features and changes
- [x] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review