### PR TITLE
Uses standard retry library for Producer put method, consolidate to single put

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       test: "curl --fail http://localhost:8080/initialized || exit 1"
       interval: 5s
       timeout: 5s
-      retries: 10
+      retries: 20
     ports:
       - "8080:8080"
     depends_on:

--- a/docs/client/getting-started.md
+++ b/docs/client/getting-started.md
@@ -84,16 +84,6 @@ object MyApp extends IOApp {
                         Record("my-data-3".getBytes(), "some-partition-key-3"),
                     )
                 )
-                // Retries failed records with a configured limit and duration.
-                _ <- producer.putWithRetry(
-                    NonEmptyList.of(
-                        Record("my-data".getBytes(), "some-partition-key"),
-                        Record("my-data-2".getBytes(), "some-partition-key-2"),
-                        Record("my-data-3".getBytes(), "some-partition-key-3"),
-                    ),
-                    Some(5),
-                    1.second
-                )
             } yield ExitCode.Success
         )
 }

--- a/docs/smithy4s/getting-started.md
+++ b/docs/smithy4s/getting-started.md
@@ -98,16 +98,6 @@ object MyApp extends IOApp {
                             Record("my-data-3".getBytes(), "some-partition-key-3"),
                         )
                     )
-                    // Retries failed records with a configured limit and duration.
-                    _ <- producer.putWithRetry(
-                        NonEmptyList.of(
-                            Record("my-data".getBytes(), "some-partition-key"),
-                            Record("my-data-2".getBytes(), "some-partition-key-2"),
-                            Record("my-data-3".getBytes(), "some-partition-key-3"),
-                        ),
-                        Some(5),
-                        1.second
-                    )
                 } yield ExitCode.Success
         )
 }

--- a/kinesis-client/src/main/scala/kinesis4cats/client/producer/KinesisProducer.scala
+++ b/kinesis-client/src/main/scala/kinesis4cats/client/producer/KinesisProducer.scala
@@ -56,7 +56,7 @@ import kinesis4cats.syntax.id._
 final class KinesisProducer[F[_]] private[kinesis4cats] (
     override val logger: StructuredLogger[F],
     override val shardMapCache: ShardMapCache[F],
-    override val config: Producer.Config,
+    override val config: Producer.Config[F],
     underlying: KinesisClient[F]
 )(implicit
     F: Async[F],
@@ -176,7 +176,7 @@ object KinesisProducer {
     *   [[cats.effect.Resource Resource]] of
     *   [[kinesis4cats.client.producer.KinesisProducer KinesisProducer]]
     */
-  def apply[F[_]](config: Producer.Config, _underlying: KinesisAsyncClient)(
+  def apply[F[_]](config: Producer.Config[F], _underlying: KinesisAsyncClient)(
       implicit
       F: Async[F],
       LE: Producer.LogEncoders,
@@ -202,7 +202,7 @@ object KinesisProducer {
     *   [[cats.effect.Resource Resource]] of
     *   [[kinesis4cats.client.producer.KinesisProducer KinesisProducer]]
     */
-  def apply[F[_]](config: Producer.Config, underlying: KinesisClient[F])(
+  def apply[F[_]](config: Producer.Config[F], underlying: KinesisClient[F])(
       implicit
       F: Async[F],
       LE: Producer.LogEncoders,

--- a/kinesis-client/src/main/scala/kinesis4cats/client/producer/fs2/FS2KinesisProducer.scala
+++ b/kinesis-client/src/main/scala/kinesis4cats/client/producer/fs2/FS2KinesisProducer.scala
@@ -47,7 +47,7 @@ import kinesis4cats.producer.fs2.FS2Producer
   */
 final class FS2KinesisProducer[F[_]] private[kinesis4cats] (
     override val logger: StructuredLogger[F],
-    override val config: FS2Producer.Config,
+    override val config: FS2Producer.Config[F],
     override protected val channel: Channel[F, Record],
     override protected val underlying: KinesisProducer[F]
 )(
@@ -85,7 +85,7 @@ object FS2KinesisProducer {
     *   [[kinesis4cats.client.producer.fs2.FS2KinesisProducer FS2KinesisProducer]]
     */
   def apply[F[_]](
-      config: FS2Producer.Config,
+      config: FS2Producer.Config[F],
       _underlying: KinesisAsyncClient,
       callback: (Producer.Res[PutRecordsResponse], Async[F]) => F[Unit] =
         (_: Producer.Res[PutRecordsResponse], f: Async[F]) => f.unit

--- a/shared/src/main/scala/kinesis4cats/producer/Producer.scala
+++ b/shared/src/main/scala/kinesis4cats/producer/Producer.scala
@@ -224,7 +224,7 @@ abstract class Producer[F[_], PutReq, PutRes](implicit
       _ <- ref.update(current =>
         Producer.RetryState(
           current.inputRecords,
-          current.res.map(x => x.combine(finalRes))
+          current.res.fold(Some(finalRes))(x => Some(x.combine(finalRes)))
         )
       )
       res <- ref.get.flatMap(x =>

--- a/shared/src/main/scala/kinesis4cats/producer/Producer.scala
+++ b/shared/src/main/scala/kinesis4cats/producer/Producer.scala
@@ -286,8 +286,8 @@ object Producer {
     *   [[kinesis4cats.producer.Producer.Error Producer.Error]] is detected in
     *   the final batch of retried put requests
     * @param retryPolicy
-    *   [[kinesis4cats.compat.retry.RetryPolicy RetryPolicy]] for retrying put
-    *   requests
+    *   [[https://github.com/etspaceman/kinesis4cats/blob/main/compat/src/main/scala/kinesis4cats/compat/retry/RetryPolicy.scala RetryPolicy]]
+    *   for retrying put requests
     */
   final case class Config[F[_]](
       warnOnShardCacheMisses: Boolean,

--- a/shared/src/main/scala/kinesis4cats/producer/Producer.scala
+++ b/shared/src/main/scala/kinesis4cats/producer/Producer.scala
@@ -18,9 +18,11 @@ package kinesis4cats.producer
 
 import scala.concurrent.duration.FiniteDuration
 
+import cats.Applicative
 import cats.Semigroup
 import cats.data.{Ior, NonEmptyList}
 import cats.effect.Async
+import cats.effect.kernel.Ref
 import cats.effect.syntax.all._
 import cats.syntax.all._
 import org.typelevel.log4cats.StructuredLogger
@@ -29,8 +31,6 @@ import kinesis4cats.compat.retry._
 import kinesis4cats.logging.{LogContext, LogEncoder}
 import kinesis4cats.models.StreamNameOrArn
 import kinesis4cats.producer.batching.Batcher
-import cats.effect.kernel.Ref
-import cats.Applicative
 
 /** An interface that gives users the ability to efficiently batch and produce
   * records. A producer has a ShardMapCache, and uses it to predict the shard
@@ -40,18 +40,18 @@ import cats.Applicative
   * (as a ShardMapCache will only consider a single stream)
   *
   * @param F
-  * [[cats.effect.Async Async]]
+  *   [[cats.effect.Async Async]]
   * @param LE
-  * [[kinesis4cats.producer.Producer.LogEncoders Producer.LogEncoders]]
+  *   [[kinesis4cats.producer.Producer.LogEncoders Producer.LogEncoders]]
   * @tparam PutReq
-  * The class that represents a batch put request for the underlying client
+  *   The class that represents a batch put request for the underlying client
   * @tparam PutRes
-  * The class that represents a batch put response for the underlying client
+  *   The class that represents a batch put response for the underlying client
   */
 abstract class Producer[F[_], PutReq, PutRes](implicit
-                                              F: Async[F],
-                                              LE: Producer.LogEncoders
-                                             ) {
+    F: Async[F],
+    LE: Producer.LogEncoders
+) {
 
   import LE._
 
@@ -66,9 +66,9 @@ abstract class Producer[F[_], PutReq, PutRes](implicit
   /** Underlying implementation for putting a batch request to Kinesis
     *
     * @param req
-    * the underlying put request
+    *   the underlying put request
     * @return
-    * the underlying put response
+    *   the underlying put response
     */
   protected def putImpl(req: PutReq): F[PutRes]
 
@@ -76,10 +76,10 @@ abstract class Producer[F[_], PutReq, PutRes](implicit
     * [[kinesis4cats.producer.Record Records]] into the underlying put request
     *
     * @param records
-    * a [[cats.data.NonEmptyList NonEmptyList]] of
-    * [[kinesis4cats.producer.Record Records]]
+    *   a [[cats.data.NonEmptyList NonEmptyList]] of
+    *   [[kinesis4cats.producer.Record Records]]
     * @return
-    * the underlying put request
+    *   the underlying put request
     */
   protected def asPutRequest(records: NonEmptyList[Record]): PutReq
 
@@ -89,38 +89,22 @@ abstract class Producer[F[_], PutReq, PutRes](implicit
     * that failed
     *
     * @param records
-    * a [[cats.data.NonEmptyList NonEmptyList]] of
-    * [[kinesis4cats.producer.Record Records]]
+    *   a [[cats.data.NonEmptyList NonEmptyList]] of
+    *   [[kinesis4cats.producer.Record Records]]
     * @param resp
-    * the underlying put response
+    *   the underlying put response
     * @return
-    * A list of
-    * [[kinesis4cats.producer.Producer.FailedRecord Producer.FailedRecord]]
+    *   A list of
+    *   [[kinesis4cats.producer.Producer.FailedRecord Producer.FailedRecord]]
     */
   protected def failedRecords(
-                               records: NonEmptyList[Record],
-                               resp: PutRes
-                             ): Option[NonEmptyList[Producer.FailedRecord]]
+      records: NonEmptyList[Record],
+      resp: PutRes
+  ): Option[NonEmptyList[Producer.FailedRecord]]
 
-  /** This function is responsible for:
-    *   - Predicting the shard that a record will land on
-    *   - Batching records against Kinesis limits for shards / streams
-    *   - Putting batches to Kinesis
-    *
-    * @param records
-    * a [[cats.data.NonEmptyList NonEmptyList]] of
-    * [[kinesis4cats.producer.Record Records]]
-    * @return
-    * [[cats.data.Ior Ior]] with the following:
-    *   - left: a [[kinesis4cats.producer.Producer.Error Producer.Error]], which
-    *     represents records that were too large to be put on kinesis as well as
-    *     records that were not produced successfully in the batch request.
-    *   - right: a [[cats.data.NonEmptyList NonEmptyList]] of the underlying put
-    *     responses
-    */
-  def put(
-           records: NonEmptyList[Record]
-         ): F[Producer.Res[PutRes]] = {
+  private def _put(
+      records: NonEmptyList[Record]
+  ): F[Producer.Res[PutRes]] = {
     val ctx = LogContext()
 
     for {
@@ -175,80 +159,90 @@ abstract class Producer[F[_], PutReq, PutRes](implicit
     } yield res
   }
 
-  def put2(records: NonEmptyList[Record]): F[Producer.Res[PutRes]] = ???
-
-  def _put2(recordsRef: Ref[F, Producer.RetryState[PutRes]]) = {
-    val ctx = LogContext()
-    ???
-  }
-
-  /** Runs the put method in a retry loop, retrying any records that failed to
-    * produce in the previous try.
+  /** This function is responsible for:
+    *   - Predicting the shard that a record will land on
+    *   - Batching records against Kinesis limits for shards / streams
+    *   - Putting batches to Kinesis
+    *   - Retrying failures per the configured RetryPolicy
     *
     * @param records
-    * a [[cats.data.NonEmptyList NonEmptyList]] of
-    * [[kinesis4cats.producer.Record Records]]
-    * @param retries
-    * Number of retries to attempt after an initial failure.
-    * @param retryDuration
-    * Amount of time to wait between retries.
+    *   a [[cats.data.NonEmptyList NonEmptyList]] of
+    *   [[kinesis4cats.producer.Record Records]]
     * @return
-    * [[cats.data.Ior Ior]] with the following:
+    *   [[cats.data.Ior Ior]] with the following:
     *   - left: a [[kinesis4cats.producer.Producer.Error Producer.Error]], which
     *     represents records that were too large to be put on kinesis as well as
     *     records that were not produced successfully in the batch request.
     *   - right: a [[cats.data.NonEmptyList NonEmptyList]] of the underlying put
     *     responses
     */
-  def putWithRetry(
-                    records: NonEmptyList[Record],
-                    retries: Option[Int],
-                    retryDuration: FiniteDuration
-                  ): F[Producer.Res[PutRes]] = {
+  def put(records: NonEmptyList[Record]): F[Producer.Res[PutRes]] = {
     val ctx = LogContext()
-      .addEncoded("retriesRemaining", retries.fold("Infinite")(_.toString()))
-      .addEncoded("retryDuration", retryDuration)
-    put(records).flatMap {
-      case x if x.isRight => F.pure(x)
-      case x if x.left.exists(e => e.errors.exists(_.isLeft)) => F.pure(x)
-      case x if retries.exists(_ <= 0) =>
-        if (config.raiseOnExhaustedRetries) {
-          x.leftTraverse(F.raiseError)
-        } else {
-          logger
-            .warn(ctx.context)(
-              "All retries have been exhausted, and the final retry detected errors"
+
+    for {
+      ref <- Ref.of(Producer.RetryState[PutRes](records, None))
+      finalRes <- retryingOnFailuresAndAllErrors(
+        config.retryPolicy,
+        (x: Producer.Res[PutRes]) =>
+          F.pure(x.isRight || x.left.exists(e => e.errors.exists(_.isLeft))),
+        (x: Producer.Res[PutRes], details: RetryDetails) =>
+          for {
+            failedRecords <- F.fromOption(
+              x.left.flatMap { e =>
+                e.errors.flatMap(errors => errors.right)
+              },
+              new RuntimeException(
+                "Failed records empty, this should never happen"
+              )
             )
-            .as(x)
-        }
-      case x =>
-        logger
-          .debug(ctx.context)("Failures detected, retrying failed records")
-          .flatMap { _ =>
-            for {
-              _ <- F.sleep(retryDuration)
-              failedRecords <- F.fromOption(
-                x.left.flatMap { e =>
-                  e.errors.flatMap(errors => errors.right)
-                },
-                new RuntimeException(
-                  "Failed records empty, this should never happen"
-                )
-              )
-              res <- putWithRetry(
+            _ <- logger.debug(ctx.addEncoded("retryDetails", details).context)(
+              s"Failures with ${failedRecords.size} records detected, retrying failed records"
+            )
+            _ <- ref.update(current =>
+              Producer.RetryState(
                 failedRecords.map(_.record),
-                retries.map(_ - 1),
-                retryDuration
+                current.res.fold(Some(x))(y => Some(y.combine(x)))
               )
-            } yield x.combine(res)
+            )
+          } yield (),
+        (e: Throwable, details: RetryDetails) =>
+          logger.error(ctx.addEncoded("retryDetails", details).context, e)(
+            "Exception when putting records, retrying"
+          )
+      )(ref.get.flatMap(x => _put(x.inputRecords)))
+      _ <-
+        if (finalRes.left.exists(e => e.errors.exists(_.right.nonEmpty))) {
+          if (config.raiseOnExhaustedRetries)
+            finalRes.leftTraverse(F.raiseError[Unit])
+          else {
+            logger
+              .warn(ctx.context)(
+                "All retries have been exhausted, and the final retry detected errors"
+              )
           }
-    }
+        } else F.unit
+      _ <- ref.update(current =>
+        Producer.RetryState(
+          current.inputRecords,
+          current.res.map(x => x.combine(finalRes))
+        )
+      )
+      res <- ref.get.flatMap(x =>
+        F.fromOption(
+          x.res,
+          new RuntimeException("Result is empty, this should never happen")
+        )
+      )
+    } yield res
   }
 }
 
 object Producer {
 
-  final private case class RetryState[A](inputRecords: NonEmptyList[Record], res: Option[Res[A]])
+  final private case class RetryState[A](
+      inputRecords: NonEmptyList[Record],
+      res: Option[Res[A]]
+  )
 
   type Res[A] = Ior[Producer.Error, NonEmptyList[A]]
   type Errs = Ior[
@@ -263,45 +257,49 @@ object Producer {
     * @param finiteDurationEncoder
     */
   final class LogEncoders(implicit
-                          val recordLogEncoder: LogEncoder[Record],
-                          val finiteDurationEncoder: LogEncoder[FiniteDuration]
-                         )
+      val recordLogEncoder: LogEncoder[Record],
+      val finiteDurationEncoder: LogEncoder[FiniteDuration],
+      val retryDetailsEncoder: LogEncoder[RetryDetails]
+  )
 
   /** Configuration for the [[kinesis4cats.producer.Producer Producer]]
     *
     * @param warnOnShardCacheMisses
-    * If true, a warning message will appear if a record was not matched with
-    * a shard in the cache
+    *   If true, a warning message will appear if a record was not matched with
+    *   a shard in the cache
     * @param warnOnBatchFailures
-    * If true, a warning message will appear if the producer failed to produce
-    * some records in a batch
+    *   If true, a warning message will appear if the producer failed to produce
+    *   some records in a batch
     * @param shardParallelism
-    * Determines how many shards to concurrently put batches of data to
+    *   Determines how many shards to concurrently put batches of data to
     * @param raiseOnFailures
-    * If true, an exception will be raised if a
-    * [[kinesis4cats.producer.Producer.Error Producer.Error]] is detected in
-    * one of the batches
+    *   If true, an exception will be raised if a
+    *   [[kinesis4cats.producer.Producer.Error Producer.Error]] is detected in
+    *   one of the batches
     * @param shardMapCacheConfig
-    * [[kinesis4cats.producer.ShardMapCache.Config ShardMapCache.Config]]
+    *   [[kinesis4cats.producer.ShardMapCache.Config ShardMapCache.Config]]
     * @param streamNameOrArn
-    * [[kinesis4cats.models.StreamNameOrArn StreamNameOrArn]] either a stream
-    * name or a stream ARN for the producer.
+    *   [[kinesis4cats.models.StreamNameOrArn StreamNameOrArn]] either a stream
+    *   name or a stream ARN for the producer.
     * @param raiseOnExhaustedRetries
-    * If true, an exception will be raised if a
-    * [[kinesis4cats.producer.Producer.Error Producer.Error]] is detected in
-    * the final batch of retried put requests
+    *   If true, an exception will be raised if a
+    *   [[kinesis4cats.producer.Producer.Error Producer.Error]] is detected in
+    *   the final batch of retried put requests
+    * @param retryPolicy
+    *   [[kinesis4cats.compat.retry.RetryPolicy RetryPolicy]] for retrying put
+    *   requests
     */
   final case class Config[F[_]](
-                                 warnOnShardCacheMisses: Boolean,
-                                 warnOnBatchFailures: Boolean,
-                                 shardParallelism: Int,
-                                 raiseOnFailures: Boolean,
-                                 shardMapCacheConfig: ShardMapCache.Config,
-                                 batcherConfig: Batcher.Config,
-                                 streamNameOrArn: StreamNameOrArn,
-                                 raiseOnExhaustedRetries: Boolean,
-                                 retryPolicy: RetryPolicy[F]
-                               )
+      warnOnShardCacheMisses: Boolean,
+      warnOnBatchFailures: Boolean,
+      shardParallelism: Int,
+      raiseOnFailures: Boolean,
+      shardMapCacheConfig: ShardMapCache.Config,
+      batcherConfig: Batcher.Config,
+      streamNameOrArn: StreamNameOrArn,
+      raiseOnExhaustedRetries: Boolean,
+      retryPolicy: RetryPolicy[F]
+  )
 
   object Config {
 
@@ -309,12 +307,14 @@ object Producer {
       * [[kinesis4cats.producer.Producer.Config Producer.Config]]
       *
       * @param streamNameOrArn
-      * [[kinesis4cats.models.StreamNameOrArn StreamNameOrArn]] either a
-      * stream name or a stream ARN for the producer.
+      *   [[kinesis4cats.models.StreamNameOrArn StreamNameOrArn]] either a
+      *   stream name or a stream ARN for the producer.
       * @return
-      * [[kinesis4cats.producer.Producer.Config Producer.Config]]
+      *   [[kinesis4cats.producer.Producer.Config Producer.Config]]
       */
-    def default[F[_]](streamNameOrArn: StreamNameOrArn)(implicit F: Applicative[F]): Config[F] = Config[F](
+    def default[F[_]](
+        streamNameOrArn: StreamNameOrArn
+    )(implicit F: Applicative[F]): Config[F] = Config[F](
       true,
       true,
       8,
@@ -330,7 +330,7 @@ object Producer {
   /** Represents errors encountered when processing records for Kinesis
     *
     * @param errors
-    * [[cats.data.Ior Ior]] with the following:
+    *   [[cats.data.Ior Ior]] with the following:
     *   - left: a [[cats.data.NonEmptyList NonEmptyList]] of
     *     [[kinesis4cats.producer.Record Records]] that were too large to fit
     *     into a single Kinesis request
@@ -348,7 +348,7 @@ object Producer {
       case Some(Ior.Both(a, b)) =>
         Error.invalidRecordsMessage(a) + "\n\nAND\n\n" + Error
           .putFailuresMessage(b)
-      case Some(Ior.Left(a)) => Error.invalidRecordsMessage(a)
+      case Some(Ior.Left(a))  => Error.invalidRecordsMessage(a)
       case Some(Ior.Right(b)) => Error.putFailuresMessage(b)
       case None => s"Batcher returned no results at all, this is unexpected"
     }
@@ -359,25 +359,25 @@ object Producer {
       (x: Error, y: Error) => x.add(y)
 
     private def invalidRecordsMessage(
-                                       records: NonEmptyList[InvalidRecord]
-                                     ): String = {
+        records: NonEmptyList[InvalidRecord]
+    ): String = {
       val prefix = s"${records.length} records were invalid."
       val recordsTooLarge = NonEmptyList
         .fromList(records.filter {
           case _: InvalidRecord.RecordTooLarge => true
-          case _ => false
+          case _                               => false
         })
         .fold("")(x => s" Records too large: ${x.length}")
       val invalidPartitionKeys = NonEmptyList
         .fromList(records.filter {
           case _: InvalidRecord.InvalidPartitionKey => true
-          case _ => false
+          case _                                    => false
         })
         .fold("")(x => s" Invalid partition keys: ${x.length}")
       val invalidExplicitHashKeys = NonEmptyList
         .fromList(records.filter {
           case _: InvalidRecord.InvalidExplicitHashKey => true
-          case _ => false
+          case _                                       => false
         })
         .fold("")(x => s" Invalid explicit hash keys: ${x.length}")
 
@@ -396,11 +396,11 @@ object Producer {
       * records that were too large to fit into Kinesis
       *
       * @param records
-      * a [[cats.data.NonEmptyList NonEmptyList]] of
-      * [[kinesis4cats.producer.Record Records]] that were too large to fit
-      * into a single Kinesis request
+      *   a [[cats.data.NonEmptyList NonEmptyList]] of
+      *   [[kinesis4cats.producer.Record Records]] that were too large to fit
+      *   into a single Kinesis request
       * @return
-      * [[kinesis4cats.producer.Producer.Error Producer.Error]]
+      *   [[kinesis4cats.producer.Producer.Error Producer.Error]]
       */
     def invalidRecords(records: NonEmptyList[InvalidRecord]): Error = Error(
       Some(Ior.left(records))
@@ -410,12 +410,12 @@ object Producer {
       * records that failed during a batch put to Kinesis.
       *
       * @param records
-      * a [[cats.data.NonEmptyList NonEmptyList]] of
-      * [[kinesis4cats.producer.Producer.FailedRecord Producer.FailedRecords]],
-      * which represent records that failed to produce to Kinesis within a
-      * given batch
+      *   a [[cats.data.NonEmptyList NonEmptyList]] of
+      *   [[kinesis4cats.producer.Producer.FailedRecord Producer.FailedRecords]],
+      *   which represent records that failed to produce to Kinesis within a
+      *   given batch
       * @return
-      * [[kinesis4cats.producer.Producer.Error Producer.Error]]
+      *   [[kinesis4cats.producer.Producer.Error Producer.Error]]
       */
     def putFailures(records: NonEmptyList[FailedRecord]): Error = Error(
       Some(Ior.right(records))
@@ -426,20 +426,20 @@ object Producer {
     * error code and message for the failure
     *
     * @param record
-    * [[kinesis4cats.producer.Record Record]] in the request that failed
+    *   [[kinesis4cats.producer.Record Record]] in the request that failed
     * @param errorCode
-    * The error code of the failure
+    *   The error code of the failure
     * @param erorrMessage
-    * The error message of the failure
+    *   The error message of the failure
     * @param requestIndex
-    * Index of record in the overarching request
+    *   Index of record in the overarching request
     */
   final case class FailedRecord(
-                                 record: Record,
-                                 errorCode: String,
-                                 erorrMessage: String,
-                                 requestIndex: Int
-                               )
+      record: Record,
+      errorCode: String,
+      erorrMessage: String,
+      requestIndex: Int
+  )
 
   /** Represents a record that was invalid per the Kinesis limits
     */
@@ -450,24 +450,24 @@ object Producer {
     /** Represents a record that was too large to put into Kinesis
       *
       * @param record
-      * Invalid [[kinesis4cats.producer.Record Record]]
+      *   Invalid [[kinesis4cats.producer.Record Record]]
       */
     final case class RecordTooLarge(record: Record) extends InvalidRecord
 
     /** Represents a partition key that was not within the Kinesis limits
       *
       * @param partitionKey
-      * Invalid partition key
+      *   Invalid partition key
       */
     final case class InvalidPartitionKey(partitionKey: String)
-      extends InvalidRecord
+        extends InvalidRecord
 
     /** Represents an explicit hash key that is in an invalid format
       *
       * @param explicitHashKey
-      * Invalid hash key
+      *   Invalid hash key
       */
     final case class InvalidExplicitHashKey(explicitHashKey: Option[String])
-      extends InvalidRecord
+        extends InvalidRecord
   }
 }

--- a/shared/src/main/scala/kinesis4cats/producer/Producer.scala
+++ b/shared/src/main/scala/kinesis4cats/producer/Producer.scala
@@ -213,7 +213,7 @@ abstract class Producer[F[_], PutReq, PutRes](implicit
       _ <-
         if (finalRes.left.exists(e => e.errors.exists(_.right.nonEmpty))) {
           if (config.raiseOnExhaustedRetries)
-            finalRes.leftTraverse(F.raiseError[Unit])
+            finalRes.leftTraverse(F.raiseError[Unit]).void
           else {
             logger
               .warn(ctx.context)(

--- a/shared/src/main/scala/kinesis4cats/producer/fs2/FS2Producer.scala
+++ b/shared/src/main/scala/kinesis4cats/producer/fs2/FS2Producer.scala
@@ -20,6 +20,7 @@ package fs2
 import scala.concurrent.duration._
 
 import _root_.fs2.concurrent.Channel
+import cats.Applicative
 import cats.data.Ior
 import cats.data.NonEmptyList
 import cats.effect._
@@ -30,9 +31,9 @@ import org.typelevel.log4cats.StructuredLogger
 import kinesis4cats.logging.LogContext
 import kinesis4cats.models.StreamNameOrArn
 
-/** An interface that runs a [[kinesis4cats.producer.Producer Producer's]]
-  * putWithRetry method in the background against a stream of records, offered
-  * by the user. This is intended to be used in the same way that the
+/** An interface that runs a [[kinesis4cats.producer.Producer Producer's]] put
+  * method in the background against a stream of records, offered by the user.
+  * This is intended to be used in the same way that the
   * [[https://github.com/awslabs/amazon-kinesis-producer KPL]].
   *
   * @param F
@@ -116,11 +117,7 @@ abstract class FS2Producer[F[_], PutReq, PutRes](implicit
                 "Received batch to process"
               )
               _ <- underlying
-                .putWithRetry(
-                  records,
-                  config.putMaxRetries,
-                  config.putRetryInterval
-                )
+                .put(records)
                 .flatMap(callback(_, implicitly))
                 .void
               _ <- logger.debug(c.context)(
@@ -169,13 +166,15 @@ object FS2Producer {
   )
 
   object Config {
-    def default[F[_]](streamNameOrArn: StreamNameOrArn): Config[F] = Config[F](
+    def default[F[_]](
+        streamNameOrArn: StreamNameOrArn
+    )(implicit F: Applicative[F]): Config[F] = Config[F](
       1000,
       500,
       100.millis,
       Some(5),
       0.seconds,
-      Producer.Config.default(streamNameOrArn),
+      Producer.Config.default[F](streamNameOrArn),
       30.seconds
     )
   }

--- a/shared/src/main/scala/kinesis4cats/producer/fs2/FS2Producer.scala
+++ b/shared/src/main/scala/kinesis4cats/producer/fs2/FS2Producer.scala
@@ -47,7 +47,7 @@ abstract class FS2Producer[F[_], PutReq, PutRes](implicit
 ) {
 
   def logger: StructuredLogger[F]
-  def config: FS2Producer.Config
+  def config: FS2Producer.Config[F]
 
   /** The underlying queue of records to process
     */
@@ -158,18 +158,18 @@ object FS2Producer {
     * @param producerConfig
     *   [[kinesis4cats.producer.Producer.Config Producer.Config]]
     */
-  final case class Config(
+  final case class Config[F[_]](
       queueSize: Int,
       putMaxChunk: Int,
       putMaxWait: FiniteDuration,
       putMaxRetries: Option[Int],
       putRetryInterval: FiniteDuration,
-      producerConfig: Producer.Config,
+      producerConfig: Producer.Config[F],
       gracefulShutdownWait: FiniteDuration
   )
 
   object Config {
-    def default(streamNameOrArn: StreamNameOrArn): Config = Config(
+    def default[F[_]](streamNameOrArn: StreamNameOrArn): Config[F] = Config[F](
       1000,
       500,
       100.millis,

--- a/smithy4s-client-localstack/src/main/scala/kinesis4cats/smithy4s/client/producer/fs2/localstack/LocalstackFS2KinesisProducer.scala
+++ b/smithy4s-client-localstack/src/main/scala/kinesis4cats/smithy4s/client/producer/fs2/localstack/LocalstackFS2KinesisProducer.scala
@@ -20,6 +20,7 @@ package fs2
 package localstack
 
 import _root_.fs2.concurrent.Channel
+import cats.Applicative
 import cats.effect._
 import cats.effect.syntax.all._
 import com.amazonaws.kinesis.PutRecordsOutput
@@ -69,7 +70,7 @@ object LocalstackFS2KinesisProducer {
   def resource[F[_]](
       client: Client[F],
       region: F[AwsRegion],
-      producerConfig: FS2Producer.Config,
+      producerConfig: FS2Producer.Config[F],
       config: LocalstackConfig,
       loggerF: Async[F] => F[StructuredLogger[F]],
       callback: (Producer.Res[PutRecordsOutput], Async[F]) => F[Unit]
@@ -146,9 +147,10 @@ object LocalstackFS2KinesisProducer {
       streamName: String,
       region: F[AwsRegion],
       prefix: Option[String] = None,
-      producerConfig: String => FS2Producer.Config = streamName =>
-        FS2Producer.Config
-          .default(StreamNameOrArn.Name(streamName)),
+      producerConfig: (String, Applicative[F]) => FS2Producer.Config[F] =
+        (streamName: String, f: Applicative[F]) =>
+          FS2Producer.Config
+            .default[F](StreamNameOrArn.Name(streamName))(f),
       loggerF: Async[F] => F[StructuredLogger[F]] = (f: Async[F]) =>
         f.pure(NoOpLogger[F](f)),
       callback: (Producer.Res[PutRecordsOutput], Async[F]) => F[Unit] =
@@ -165,7 +167,7 @@ object LocalstackFS2KinesisProducer {
       resource[F](
         client,
         region,
-        producerConfig(streamName),
+        producerConfig(streamName, F),
         _,
         loggerF,
         callback

--- a/smithy4s-client/src/main/scala/kinesis4cats/smithy4s/client/producer/KinesisProducer.scala
+++ b/smithy4s-client/src/main/scala/kinesis4cats/smithy4s/client/producer/KinesisProducer.scala
@@ -57,7 +57,7 @@ import kinesis4cats.producer.{Record => Rec, _}
 final class KinesisProducer[F[_]] private[kinesis4cats] (
     override val logger: StructuredLogger[F],
     override val shardMapCache: ShardMapCache[F],
-    override val config: Producer.Config,
+    override val config: Producer.Config[F],
     underlying: KinesisClient[F]
 )(implicit
     F: Async[F],
@@ -184,7 +184,7 @@ object KinesisProducer {
     *   [[kinesis4cats.smithy4s.client.producer.KinesisProducer KinesisProducer]]
     */
   def apply[F[_]](
-      config: Producer.Config,
+      config: Producer.Config[F],
       client: Client[F],
       region: F[AwsRegion],
       loggerF: Async[F] => F[StructuredLogger[F]] = (f: Async[F]) =>

--- a/smithy4s-client/src/main/scala/kinesis4cats/smithy4s/client/producer/fs2/FS2KinesisProducer.scala
+++ b/smithy4s-client/src/main/scala/kinesis4cats/smithy4s/client/producer/fs2/FS2KinesisProducer.scala
@@ -53,7 +53,7 @@ import kinesis4cats.producer.fs2.FS2Producer
   */
 final class FS2KinesisProducer[F[_]] private[kinesis4cats] (
     override val logger: StructuredLogger[F],
-    override val config: FS2Producer.Config,
+    override val config: FS2Producer.Config[F],
     override protected val channel: Channel[F, Record],
     override protected val underlying: KinesisProducer[F]
 )(
@@ -103,7 +103,7 @@ object FS2KinesisProducer {
     *   [[kinesis4cats.smithy4s.client.producer.KinesisProducer KinesisProducer]]
     */
   def apply[F[_]](
-      config: FS2Producer.Config,
+      config: FS2Producer.Config[F],
       client: Client[F],
       region: F[AwsRegion],
       loggerF: Async[F] => F[StructuredLogger[F]] = (f: Async[F]) =>


### PR DESCRIPTION
## Changes Introduced

- Allows users to configure a retry routine using the standard cats-retry compat library included in kinesis4cats, rather than a pre-defined, crude policy
- Single method for producers, now configured via the Config class for retries
- Default retries will always give up on the first error.

## Applicable linked issues

#97 

## Checklist (check all that apply)

- [ ] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [X] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review