### PR TITLE
Release as java-8 for most modules, java-11 for smithy4s modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -254,7 +254,8 @@ lazy val `smithy4s-client-transformers` = projectMatrix
     description := "Transformers for the smithy4s-client project",
     libraryDependencies ++= Seq(
       Smithy.build(smithy4s.codegen.BuildInfo.smithyVersion)
-    )
+    ),
+    tlJdkRelease := Some(11)
   )
   .jvmPlatform(List(Scala212))
 
@@ -281,7 +282,8 @@ lazy val `smithy4s-client` = projectMatrix
         Scala212
       ) / Compile / packageBin).value,
     Compile / smithy4sSmithyLibrary := false,
-    scalacOptions -= "-deprecation"
+    scalacOptions -= "-deprecation",
+    tlJdkRelease := Some(11)
   )
   .jvmPlatform(last2ScalaVersions)
   .nativePlatform(Seq(Scala3))
@@ -291,7 +293,8 @@ lazy val `smithy4s-client` = projectMatrix
 lazy val `smithy4s-client-logging-circe` = projectMatrix
   .settings(
     description := "JSON structured logging instances for the Smithy4s Kinesis Client, via Circe",
-    libraryDependencies ++= Seq(Http4s.circe.value)
+    libraryDependencies ++= Seq(Http4s.circe.value),
+    tlJdkRelease := Some(11)
   )
   .jvmPlatform(last2ScalaVersions)
   .nativePlatform(Seq(Scala3))
@@ -300,7 +303,8 @@ lazy val `smithy4s-client-logging-circe` = projectMatrix
 
 lazy val `smithy4s-client-localstack` = projectMatrix
   .settings(
-    description := "A test-kit for working with Kinesis and Localstack, via the Smithy4s Client project"
+    description := "A test-kit for working with Kinesis and Localstack, via the Smithy4s Client project",
+    tlJdkRelease := Some(11)
   )
   .jvmPlatform(last2ScalaVersions)
   .nativePlatform(Seq(Scala3))
@@ -330,7 +334,8 @@ lazy val integrationTestsJvmSettings: Seq[Setting[_]] = Seq(
       }
     case x => MergeStrategy.defaultMergeStrategy(x)
   },
-  assembly / mainClass := Some("kinesis4cats.kcl.http4s.TestKCLService")
+  assembly / mainClass := Some("kinesis4cats.kcl.http4s.TestKCLService"),
+  tlJdkRelease := Some(11)
 )
 
 lazy val integrationTestsJvmDependencies = List(

--- a/kpl/src/main/scala/kinesis4cats/kpl/KPLProducer.scala
+++ b/kpl/src/main/scala/kinesis4cats/kpl/KPLProducer.scala
@@ -97,7 +97,8 @@ class KPLProducer[F[_]] private (
     *   Optional hash key, used to explicitly set the shard and override the
     *   partitionKey hash.
     * @param data
-    *   [[java.nio.ByteBuffer]] representing the data to be produced
+    *   [[https://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html ByteBuffer]]
+    *   representing the data to be produced
     * @return
     *   F of
     *   [[https://github.com/awslabs/amazon-kinesis-producer/blob/master/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/UserRecordResult.java UserRecordResult]]
@@ -154,7 +155,8 @@ class KPLProducer[F[_]] private (
     *   Optional hash key, used to explicitly set the shard and override the
     *   partitionKey hash.
     * @param data
-    *   [[java.nio.ByteBuffer]] representing the data to be produced
+    *   [[https://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html ByteBuffer]]
+    *   representing the data to be produced
     * @param schema
     *   [[https://github.com/awslabs/aws-glue-schema-registry/blob/master/common/src/main/java/com/amazonaws/services/schemaregistry/common/Schema.java Schema]]
     *   representing a glue schema for this event

--- a/project/Kinesis4CatsPlugin.scala
+++ b/project/Kinesis4CatsPlugin.scala
@@ -25,6 +25,7 @@ object Kinesis4CatsPlugin extends AutoPlugin {
   import TypelevelCiPlugin.autoImport._
   import TypelevelGitHubPlugin.autoImport._
   import TypelevelKernelPlugin.autoImport._
+  import TypelevelSettingsPlugin.autoImport._
   import TypelevelSitePlugin.autoImport._
   import TypelevelVersioningPlugin.autoImport._
   import autoImport._
@@ -257,7 +258,8 @@ object Kinesis4CatsPlugin extends AutoPlugin {
       else (Compile / doc / sources).value
     },
     assembly / test := {},
-    Test / parallelExecution := false
+    Test / parallelExecution := false,
+    tlJdkRelease := Some(8)
   ) ++ Seq(
     addCommandAlias(
       "cpl",

--- a/shared/src/main/scala/kinesis4cats/syntax/bytebuffer.scala
+++ b/shared/src/main/scala/kinesis4cats/syntax/bytebuffer.scala
@@ -31,8 +31,10 @@ trait ByteBufferSyntax {
 object ByteBufferSyntax {
   final class ByteBufferOps(private val buffer: ByteBuffer) extends AnyVal {
 
-    /** Safely copies the contents of a [[java.nio.ByteBuffer]] to a byte array.
-      * Will ensure that the ByteBuffer's current state remains intact.
+    /** Safely copies the contents of a
+      * [[https://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html ByteBuffer]]
+      * to a byte array. Will ensure that the ByteBuffer's current state remains
+      * intact.
       *
       * @return
       *   Byte array with the contents of the ByteBuffer
@@ -46,17 +48,20 @@ object ByteBufferSyntax {
       arr
     }
 
-    /** Safely copies the content of a [[java.nio.ByteBuffer]] into a string.
-      * Will ensure that the ByteBuffer's current state remains intact.
+    /** Safely copies the content of a
+      * [[https://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html ByteBuffer]]
+      * into a string. Will ensure that the ByteBuffer's current state remains
+      * intact.
       *
       * @return
       *   String with the contents of the ByteBuffer
       */
     def asString: String = new String(asArray)
 
-    /** Safely copies the content of a [[java.nio.ByteBuffer]] into a Base64.
-      * encoded string. Will ensure that the ByteBuffer's current state remains
-      * intact.
+    /** Safely copies the content of a
+      * [[[https://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html ByteBuffer]]
+      * into a Base64. encoded string. Will ensure that the ByteBuffer's current
+      * state remains intact.
       *
       * @return
       *   Base64 string with the contents of the ByteBuffer

--- a/smithy4s-client-transformers/src/main/scala/kinesis4cats/smithy4s/client/KinesisSpecTransformer.scala
+++ b/smithy4s-client-transformers/src/main/scala/kinesis4cats/smithy4s/client/KinesisSpecTransformer.scala
@@ -20,6 +20,7 @@ import java.util.ArrayList
 import java.util.Collections
 import java.util.function
 import java.util.function.BiFunction
+import java.util.stream.Collectors
 
 import software.amazon.smithy.build._
 import software.amazon.smithy.model.Model
@@ -106,7 +107,7 @@ final class KinesisSpecTransformer extends ProjectionTransformer {
                 .build()
             else member
           }
-          .toList()
+          .collect(Collectors.toList())
 
       shape
         .asStructureShape()
@@ -121,7 +122,9 @@ final class KinesisSpecTransformer extends ProjectionTransformer {
 
     val withMappedTraits =
       transformer.mapTraits(context.getModel(), traitTransform)
-    val newShapesAl = new ArrayList[Shape](withMappedTraits.shapes().toList())
+    val newShapesAl = new ArrayList[Shape](
+      withMappedTraits.shapes().collect(Collectors.toList())
+    )
     newShapesAl.add(nonNegativeIntegerObjectShape)
 
     val newShapes = Collections.unmodifiableList(newShapesAl)


### PR DESCRIPTION
## Changes Introduced

Allows for JDK 8+ applications to leverage the library. 

JDK 11+ is required for Smithy4s due to [Jsoniter](https://github.com/plokhotnyuk/jsoniter-scala#goals)

## Applicable linked issues

#119 

## Checklist (check all that apply)

- [ ] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review