### PR TITLE
Update protocol in Localstack proxy

### DIFF
--- a/smithy4s-client-localstack/src/main/scala/kinesis4cats/smithy4s/client/middleware/LocalstackProxy.scala
+++ b/smithy4s-client-localstack/src/main/scala/kinesis4cats/smithy4s/client/middleware/LocalstackProxy.scala
@@ -26,6 +26,8 @@ import org.typelevel.ci._
 import org.typelevel.log4cats.StructuredLogger
 
 import kinesis4cats.localstack.LocalstackConfig
+import kinesis4cats.localstack.Protocol.Http
+import kinesis4cats.localstack.Protocol.Https
 import kinesis4cats.logging.LogContext
 import kinesis4cats.smithy4s.client.localstack.LocalstackKinesisClient
 
@@ -62,13 +64,19 @@ object LocalstackProxy {
     import encoders.localstackConfigEncoders._
     val newReq = req
       .withUri(
-        req.uri.copy(authority =
-          req.uri.authority.map(x =>
+        req.uri.copy(
+          authority = req.uri.authority.map(x =>
             x.copy(
               host = Uri.RegName(config.kinesisHost),
               port = config.kinesisPort.some
             )
-          )
+          ),
+          scheme = Some {
+            config.kinesisProtocol match {
+              case Http  => Uri.Scheme.http
+              case Https => Uri.Scheme.https
+            }
+          }
         )
       )
       .putHeaders(Header.Raw(ci"host", config.kinesisHost))


### PR DESCRIPTION
## Changes Introduced

The LS proxy wasn't updating the protocol, making it seemingly impossible not to use HTTPS.

## Applicable linked issues

none

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes - nope, but a manual test confirms that this works
- [ ] I have added documentation covering all new features and changes - I think there's nothing to document as this was a bug
- [x] This pull-request is ready for review