### PR TITLE
Shade Smithy4s Generated Classes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -283,7 +283,7 @@ val removeSmithy4sDependenciesFromManifest =
     }
   }
 lazy val `smithy4s-client` = projectMatrix
-  .enablePlugins(Smithy4sCodegenPlugin)
+  .enablePlugins(Smithy4sCodegenPlugin, ShadingPlugin)
   .settings(
     description := "Cats tooling for the Smithy4s Kinesis Client",
     libraryDependencies ++= Seq(
@@ -307,7 +307,22 @@ lazy val `smithy4s-client` = projectMatrix
     Compile / smithy4sSmithyLibrary := false,
     scalacOptions -= "-deprecation",
     tlJdkRelease := Some(11),
-    removeSmithy4sDependenciesFromManifest
+    removeSmithy4sDependenciesFromManifest,
+    shadedModules += S4S.kinesis.module,
+    shadedModules += Smithy
+      .rulesEngine(smithy4s.codegen.BuildInfo.smithyVersion)
+      .module,
+    shadingRules ++= Seq(
+      ShadingRule.moveUnder(
+        "smithy.rules",
+        "kinesis4cats.internal.shaded.smithy4s.rules"
+      ),
+      ShadingRule.moveUnder(
+        "com.amazonaws",
+        "kinesis4cats.internal.shaded.com.amazonaws"
+      )
+    ),
+    validNamespaces += "kinesis4cats"
   )
   .jvmPlatform(last2ScalaVersions)
   .nativePlatform(Seq(Scala3))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,6 +22,8 @@ addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
 // Older versions exit sbt on compilation failures.
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.7")
 
+addSbtPlugin("io.get-coursier" % "sbt-shading" % "2.1.1")
+
 libraryDependencies ++= Seq(
   "com.thesamet.scalapb" %% "compilerplugin" % "0.11.13",
   "org.slf4j" % "slf4j-nop" % "2.0.7"


### PR DESCRIPTION
## Changes Introduced

Shades the generated classes for the Smithy4s Client to avoid conflicts with downstream user builds.

## Applicable linked issues

#122 

## Checklist (check all that apply)

- [ ] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review