### PR TITLE
Add missing method

### DIFF
--- a/smithy4s-client/src/main/scala/kinesis4cats/smithy4s/client/producer/fs2/FS2KinesisProducer.scala
+++ b/smithy4s-client/src/main/scala/kinesis4cats/smithy4s/client/producer/fs2/FS2KinesisProducer.scala
@@ -95,6 +95,10 @@ object FS2KinesisProducer {
       copy(encoders = encoders)
     def withLogRequestsResponses(logRequestsResponses: Boolean): Builder[F] =
       copy(logRequestsResponses = logRequestsResponses)
+    def withCallback(
+        callback: Producer.Result[PutRecordsOutput] => F[Unit]
+    ): Builder[F] =
+      copy(callback = callback)
     def enableLogging: Builder[F] = withLogRequestsResponses(true)
     def disableLogging: Builder[F] = withLogRequestsResponses(false)
 


### PR DESCRIPTION
Adding missing method to set `Fs2KinesisProducer` callback.

Perhaps `Producer.Result` should be exposed too? Currently it is possible to pass a callback, but the type cannot be directly referred to.