### PR TITLE
Fix FS2Producer Resource Bug

### DIFF
--- a/shared/src/main/scala/kinesis4cats/producer/fs2/FS2Producer.scala
+++ b/shared/src/main/scala/kinesis4cats/producer/fs2/FS2Producer.scala
@@ -134,7 +134,7 @@ abstract class FS2Producer[F[_], PutReq, PutRes](implicit
   private[kinesis4cats] def resource: Resource[F, Unit] = for {
     deferredError <- Deferred[F, Throwable].toResource
     _ <- Resource
-      .make(start(deferredError).start)(stop)
+      .make(start(deferredError))(stop)
       .void
       .race(deferredError.get.flatMap(F.raiseError[Unit]).toResource)
   } yield ()


### PR DESCRIPTION
## Changes Introduced

The FS2Producer was racing two resources, but one of those resources would complete immediately due to an extra .start call.

## Applicable linked issues

## Checklist (check all that apply)

- [ ] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review