### PR TITLE
Use shardBatch instead of records for failedRecords

### DIFF
--- a/shared/src/main/scala/kinesis4cats/producer/Producer.scala
+++ b/shared/src/main/scala/kinesis4cats/producer/Producer.scala
@@ -142,7 +142,7 @@ abstract class Producer[F[_], PutReq, PutRes] private[kinesis4cats] (
               .parTraverseN(config.shardParallelism) { shardBatch =>
                 putImpl(asPutRequest(shardBatch))
                   .map(resp =>
-                    failedRecords(records, resp)
+                    failedRecords(shardBatch, resp)
                       .map(Producer.Result.putFailures[PutRes])
                       .fold(
                         Producer.Result.success(resp)


### PR DESCRIPTION
## Changes Introduced

The failedRecords implementation was bugged because it was using `records` instead of `shardBatch`, meaning that the wrong records would be captured for retries. 

## Applicable linked issues

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review