### PR TITLE
Don't re-aggregate on retries

### DIFF
--- a/shared/src/main/scala/kinesis4cats/producer/Producer.scala
+++ b/shared/src/main/scala/kinesis4cats/producer/Producer.scala
@@ -65,7 +65,9 @@ abstract class Producer[F[_], PutReq, PutRes] private[kinesis4cats] (
 
   def config: Producer.Config[F]
 
-  private lazy val batcher: Batcher = new Batcher(config.batcherConfig)
+  private[kinesis4cats] lazy val batcher: Batcher = new Batcher(
+    config.batcherConfig
+  )
 
   /** Underlying implementation for putting a batch request to Kinesis
     *

--- a/shared/src/main/scala/kinesis4cats/producer/Producer.scala
+++ b/shared/src/main/scala/kinesis4cats/producer/Producer.scala
@@ -107,7 +107,8 @@ abstract class Producer[F[_], PutReq, PutRes] private[kinesis4cats] (
   ): Option[NonEmptyList[Producer.FailedRecord]]
 
   private def _put(
-      records: NonEmptyList[Record]
+      records: NonEmptyList[Record],
+      retrying: Boolean
   ): F[Producer.Result[PutRes]] = {
     val ctx = LogContext()
 
@@ -133,7 +134,7 @@ abstract class Producer[F[_], PutReq, PutRes] private[kinesis4cats] (
             else F.unit
         } yield Record.WithShard.fromOption(rec, shardRes.toOption)
       )
-      batched = batcher.batch(withShards)
+      batched = batcher.batch(withShards, retrying)
       res <-
         batched.batches
           .flatTraverse(batch =>
@@ -174,7 +175,7 @@ abstract class Producer[F[_], PutReq, PutRes] private[kinesis4cats] (
     val ctx = LogContext()
 
     for {
-      ref <- Ref.of(Producer.RetryState[PutRes](records, None))
+      ref <- Ref.of(Producer.RetryState[PutRes](records, None, false))
       finalRes <- retryingOnFailuresAndAllErrors(
         config.retryPolicy,
         (x: Producer.Result[PutRes]) =>
@@ -201,7 +202,8 @@ abstract class Producer[F[_], PutReq, PutRes] private[kinesis4cats] (
                       failed.toList // Only use failed from most recent result
                     )
                   )
-                }
+                },
+                true
               )
             )
           } yield (),
@@ -209,7 +211,7 @@ abstract class Producer[F[_], PutReq, PutRes] private[kinesis4cats] (
           logger.warn(ctx.addEncoded("retryDetails", details).context, e)(
             "Exception when putting records, retrying"
           )
-      )(ref.get.flatMap(x => _put(x.inputRecords)))
+      )(ref.get.flatMap(x => _put(x.inputRecords, x.retrying)))
       _ <-
         if (finalRes.hasFailed) {
           if (config.raiseOnFailures) {
@@ -234,7 +236,8 @@ abstract class Producer[F[_], PutReq, PutRes] private[kinesis4cats] (
         (
           Producer.RetryState(
             current.inputRecords,
-            Some(result)
+            Some(result),
+            current.retrying
           ),
           result
         )
@@ -247,7 +250,8 @@ object Producer {
 
   final private case class RetryState[A](
       inputRecords: NonEmptyList[Record],
-      res: Option[Result[A]]
+      res: Option[Result[A]],
+      retrying: Boolean
   )
 
   private[kinesis4cats] final case class Result[A](

--- a/shared/src/main/scala/kinesis4cats/producer/batching/Batcher.scala
+++ b/shared/src/main/scala/kinesis4cats/producer/batching/Batcher.scala
@@ -36,8 +36,8 @@ private[kinesis4cats] final class Batcher(config: Batcher.Config) {
     *   [[cats.data.NonEmptyList NonEmptyList]] of
     *   [[kinesis4cats.producer.Record.WithShard records]]
     * @param retrying
-    *   Determines if the batcher is being executed during a retry. This helps to
-    *   avoid re-aggregation of data during retries
+    *   Determines if the batcher is being executed during a retry. This helps
+    *   to avoid re-aggregation of data during retries
     * @return
     *   [[kinesis4cats.producer.batching.Batcher.Result Batcher.Result]]
     */
@@ -92,7 +92,7 @@ private[kinesis4cats] final class Batcher(config: Batcher.Config) {
     * @return
     *   List of batches
     */
-  private def _aggregateAndBatch(
+  private[kinesis4cats] def _aggregateAndBatch(
       records: NonEmptyList[Record.WithShard]
   ): Option[NonEmptyList[Batch]] = {
     val aggregated =

--- a/shared/src/main/scala/kinesis4cats/producer/batching/Batcher.scala
+++ b/shared/src/main/scala/kinesis4cats/producer/batching/Batcher.scala
@@ -35,11 +35,15 @@ private[kinesis4cats] final class Batcher(config: Batcher.Config) {
     * @param records
     *   [[cats.data.NonEmptyList NonEmptyList]] of
     *   [[kinesis4cats.producer.Record.WithShard records]]
+    * @param retrying
+    *   Determines if the batcher is being executed during a retry. This helps to
+    *   avoid re-aggregation of data during retries
     * @return
     *   [[kinesis4cats.producer.batching.Batcher.Result Batcher.Result]]
     */
   def batch(
-      records: NonEmptyList[Record.WithShard]
+      records: NonEmptyList[Record.WithShard],
+      retrying: Boolean
   ): Batcher.Result = {
     val errors = records.collect {
       case record
@@ -66,7 +70,10 @@ private[kinesis4cats] final class Batcher(config: Batcher.Config) {
 
     val batchRes: List[Batch] = NonEmptyList
       .fromList(valid)
-      .flatMap(x => if (config.aggregate) _aggregateAndBatch(x) else _batch(x))
+      .flatMap(x =>
+        if (config.aggregate && !retrying) _aggregateAndBatch(x)
+        else _batch(x)
+      )
       .map(_.toList)
       .getOrElse(Nil)
 

--- a/shared/src/test/scala/kinesis4cats/producer/batching/BatcherSpec.scala
+++ b/shared/src/test/scala/kinesis4cats/producer/batching/BatcherSpec.scala
@@ -59,7 +59,7 @@ class BatcherSpec extends munit.CatsEffectSuite {
         )
     )
 
-    val res = batcher.batch(records)
+    val res = batcher.batch(records, false)
     assert(res.isSuccessful)
     assert(res === expected, s"res: $res\nexp: $expected")
   }
@@ -101,7 +101,7 @@ class BatcherSpec extends munit.CatsEffectSuite {
         )
     )
 
-    val res = batcher.batch(records.map(_._2))
+    val res = batcher.batch(records.map(_._2), false)
     assert(res.isSuccessful)
     assert(res === expected, s"res: $res\nexp: $expected")
   }
@@ -137,7 +137,7 @@ class BatcherSpec extends munit.CatsEffectSuite {
         )
     )
 
-    val res = batcher.batch(records)
+    val res = batcher.batch(records, false)
     assert(res.isSuccessful)
     assert(res === expected, s"res: $res\nexp: $expected")
   }
@@ -179,7 +179,7 @@ class BatcherSpec extends munit.CatsEffectSuite {
         )
     )
 
-    val res = batcher.batch(records.map(_._2))
+    val res = batcher.batch(records.map(_._2), false)
     assert(res.isSuccessful)
     assert(res === expected, s"res: $res\nexp: $expected")
   }
@@ -197,7 +197,7 @@ class BatcherSpec extends munit.CatsEffectSuite {
       records.map(x => Producer.InvalidRecord.RecordTooLarge(x.record)).toList,
       Nil
     )
-    val res = batcher.batch(records)
+    val res = batcher.batch(records, false)
     assert(res.hasInvalid)
     assert(res === expected, s"res: $res\nexp: $expected")
   }
@@ -242,7 +242,7 @@ class BatcherSpec extends munit.CatsEffectSuite {
       }
     )
 
-    val res = batcher.batch(badRecords ::: goodRecords.map(_._2))
+    val res = batcher.batch(badRecords ::: goodRecords.map(_._2), false)
     assert(res.isPartiallySuccessful)
     assert(res === expected, s"res: $res\nexp: $expected")
   }


### PR DESCRIPTION
## Changes Introduced

This fixes a bug where records were re-aggregated when retried, leading to bad data.

## Applicable linked issues

#263 

## Checklist (check all that apply)

- [X] This change maintains backwards compatibility
- [X] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review