### PR TITLE
KCLConsumerFS2 should have autoCommit = false

### DIFF
--- a/kcl/src/main/scala/kinesis4cats/kcl/fs2/KCLConsumerFS2.scala
+++ b/kcl/src/main/scala/kinesis4cats/kcl/fs2/KCLConsumerFS2.scala
@@ -245,7 +245,9 @@ object KCLConsumerFS2 {
         F: Async[F],
         P: Parallel[F]
     ): Builder[F] = Builder(
-      config = KCLConsumer.BuilderConfig.Make.default(appName, streamTracker),
+      config = KCLConsumer.BuilderConfig.Make
+        .default(appName, streamTracker)
+        .andThen(_.withProcessConfig(defaultProcessConfig)),
       mkKinesisClient = Resource.fromAutoCloseable(
         Sync[F].delay(KinesisAsyncClient.create())
       ),


### PR DESCRIPTION
## Changes Introduced

KCLConsumerFS2 now has autoCommit = false. 

## Applicable linked issues

#262 

## Checklist (check all that apply)

- [X] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [X] This pull-request is ready for review