### PR TITLE
Fix for Deaggregating non-aggregated values

### DIFF
--- a/shared/src/test/scala/kinesis4cats/consumer/RecordSpec.scala
+++ b/shared/src/test/scala/kinesis4cats/consumer/RecordSpec.scala
@@ -62,4 +62,24 @@ final class RecordSpec extends munit.FunSuite {
     assert(res(1).data.toArray.sameElements(data2))
     assert(res(1).partitionKey === partitionKey2)
   }
+
+  test("Deaggregate should not fail for non-aggregated records") {
+    val data1 = "foo".getBytes()
+    val partitionKey1 = "foo"
+
+    val record = Record(
+      "foo",
+      Instant.now(),
+      ByteVector(data1),
+      partitionKey1,
+      None,
+      None,
+      None
+    )
+
+    val res = Record.deaggregate(List(record)).get
+
+    assert(res.head.data.toArray.sameElements(data1))
+    assert(res.head.partitionKey === partitionKey1)
+  }
 }


### PR DESCRIPTION
## Changes Introduced

`dataArray` was eagerly calculated in `Record` which doesn't make sense for non-aggregated values. This caused some records to throw. 

## Applicable linked issues

#453 

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [x] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review